### PR TITLE
Expand Discord bot with modular commands

### DIFF
--- a/commands/8ball.js
+++ b/commands/8ball.js
@@ -1,0 +1,20 @@
+module.exports = {
+  name: '8ball',
+  description: 'Odpowiada na pytania tak/nie',
+  execute(message, args) {
+    if (!args.length) {
+      return message.reply('Zadaj pytanie.');
+    }
+    const responses = [
+      'Tak',
+      'Nie',
+      'Może',
+      'Z pewnością',
+      'Wątpię',
+      'Oczywiście',
+      'Nie chcesz wiedzieć'
+    ];
+    const response = responses[Math.floor(Math.random() * responses.length)];
+    message.channel.send(response);
+  }
+};

--- a/commands/ban.js
+++ b/commands/ban.js
@@ -1,0 +1,22 @@
+const { PermissionsBitField } = require('discord.js');
+
+module.exports = {
+  name: 'ban',
+  description: 'Banuje wskazanego użytkownika',
+  async execute(message) {
+    if (!message.member.permissions.has(PermissionsBitField.Flags.BanMembers)) {
+      return message.reply('Nie masz uprawnień do banowania użytkowników.');
+    }
+    const member = message.mentions.members.first();
+    if (!member) {
+      return message.reply('Oznacz użytkownika do zbanowania.');
+    }
+    try {
+      await member.ban();
+      message.channel.send(`Użytkownik ${member.user.tag} został zbanowany.`);
+    } catch (err) {
+      console.error(err);
+      message.reply('Nie udało się zbanować użytkownika.');
+    }
+  }
+};

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'help',
+  description: 'Wyświetla listę komend',
+  execute(message) {
+    const commands = message.client.commands.map(cmd => `**!${cmd.name}** - ${cmd.description}`).join('\n');
+    message.channel.send(`Dostępne komendy:\n${commands}`);
+  }
+};

--- a/commands/kick.js
+++ b/commands/kick.js
@@ -1,0 +1,22 @@
+const { PermissionsBitField } = require('discord.js');
+
+module.exports = {
+  name: 'kick',
+  description: 'Wyrzuca wskazanego użytkownika z serwera',
+  async execute(message) {
+    if (!message.member.permissions.has(PermissionsBitField.Flags.KickMembers)) {
+      return message.reply('Nie masz uprawnień do wyrzucania użytkowników.');
+    }
+    const member = message.mentions.members.first();
+    if (!member) {
+      return message.reply('Oznacz użytkownika do wyrzucenia.');
+    }
+    try {
+      await member.kick();
+      message.channel.send(`Użytkownik ${member.user.tag} został wyrzucony.`);
+    } catch (err) {
+      console.error(err);
+      message.reply('Nie udało się wyrzucić użytkownika.');
+    }
+  }
+};

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: 'ping',
+  description: 'Sprawdź czy bot działa',
+  execute(message) {
+    message.reply('Pong!');
+  }
+};

--- a/commands/poll.js
+++ b/commands/poll.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'poll',
+  description: 'Tworzy prostą ankietę z reakcjami 👍 i 👎',
+  async execute(message, args) {
+    if (!args.length) {
+      return message.reply('Podaj treść ankiety.');
+    }
+    const question = args.join(' ');
+    const pollMessage = await message.channel.send(`\uD83D\uDCCA **${question}**`);
+    await pollMessage.react('👍');
+    await pollMessage.react('👎');
+  }
+};

--- a/commands/siema.js
+++ b/commands/siema.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: 'siema',
+  description: 'Przywitaj się z botem',
+  execute(message) {
+    message.reply('Siemano, co tam wariacie?');
+  }
+};

--- a/commands/userinfo.js
+++ b/commands/userinfo.js
@@ -1,0 +1,18 @@
+module.exports = {
+  name: 'userinfo',
+  description: 'Wyświetla informacje o użytkowniku',
+  execute(message) {
+    const user = message.author;
+    const member = message.guild.members.cache.get(user.id);
+    const embed = {
+      color: 0x0099ff,
+      title: user.tag,
+      thumbnail: { url: user.displayAvatarURL() },
+      fields: [
+        { name: 'Dołączył na serwer', value: member.joinedAt.toDateString(), inline: true },
+        { name: 'Utworzone konto', value: user.createdAt.toDateString(), inline: true }
+      ]
+    };
+    message.channel.send({ embeds: [embed] });
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,21 +1,50 @@
+// Load environment variables
 require('dotenv').config();
 
-const { Client, GatewayIntentBits } = require('discord.js');
+const { Client, Collection, GatewayIntentBits, Partials } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.GuildMembers,
     GatewayIntentBits.MessageContent
-  ]
+  ],
+  partials: [Partials.Channel]
+});
+
+client.commands = new Collection();
+const prefix = '!';
+
+const commandsPath = path.join(__dirname, 'commands');
+fs.readdirSync(commandsPath).forEach(file => {
+  if (file.endsWith('.js')) {
+    const command = require(path.join(commandsPath, file));
+    if (command && command.name && command.execute) {
+      client.commands.set(command.name, command);
+    }
+  }
 });
 
 client.once('ready', () => {
-  console.log(`✅ Zalogowano jako ${client.user.tag}`);
+  console.log(`✅ Logged in as ${client.user.tag}`);
 });
 
-client.on('messageCreate', message => {
-  if (message.content === '!siema') {
-    message.reply('Siemano, co tam wariacie?');
+client.on('messageCreate', async message => {
+  if (!message.content.startsWith(prefix) || message.author.bot) return;
+  const args = message.content.slice(prefix.length).trim().split(/ +/);
+  const commandName = args.shift().toLowerCase();
+
+  const command = client.commands.get(commandName);
+  if (!command) return;
+
+  try {
+    await command.execute(message, args);
+  } catch (error) {
+    console.error(error);
+    message.reply('❌ Wystąpił błąd podczas wykonywania komendy.');
   }
 });
 


### PR DESCRIPTION
## Summary
- implement command handler in `index.js`
- add multiple commands including help, userinfo, kick, ban, poll, 8ball and more

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684abb6f60948325a1dc2e5025dc7996