### PR TITLE
Enable Discord slash commands

### DIFF
--- a/commands/8ball.js
+++ b/commands/8ball.js
@@ -1,10 +1,15 @@
+const { SlashCommandBuilder } = require('discord.js');
+
 module.exports = {
-  name: '8ball',
-  description: 'Odpowiada na pytania tak/nie',
-  execute(message, args) {
-    if (!args.length) {
-      return message.reply('Zadaj pytanie.');
-    }
+  data: new SlashCommandBuilder()
+    .setName('8ball')
+    .setDescription('Odpowiada na pytania tak/nie')
+    .addStringOption(option =>
+      option.setName('pytanie')
+        .setDescription('Treść pytania')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
     const responses = [
       'Tak',
       'Nie',
@@ -15,6 +20,6 @@ module.exports = {
       'Nie chcesz wiedzieć'
     ];
     const response = responses[Math.floor(Math.random() * responses.length)];
-    message.channel.send(response);
+    await interaction.reply(response);
   }
 };

--- a/commands/ban.js
+++ b/commands/ban.js
@@ -1,22 +1,28 @@
-const { PermissionsBitField } = require('discord.js');
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
 
 module.exports = {
-  name: 'ban',
-  description: 'Banuje wskazanego użytkownika',
-  async execute(message) {
-    if (!message.member.permissions.has(PermissionsBitField.Flags.BanMembers)) {
-      return message.reply('Nie masz uprawnień do banowania użytkowników.');
+  data: new SlashCommandBuilder()
+    .setName('ban')
+    .setDescription('Banuje wskazanego użytkownika')
+    .addUserOption(option =>
+      option.setName('uzytkownik')
+        .setDescription('Użytkownik do zbanowania')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionsBitField.Flags.BanMembers)) {
+      return interaction.reply({ content: 'Nie masz uprawnień do banowania użytkowników.', ephemeral: true });
     }
-    const member = message.mentions.members.first();
+    const member = interaction.options.getMember('uzytkownik');
     if (!member) {
-      return message.reply('Oznacz użytkownika do zbanowania.');
+      return interaction.reply({ content: 'Nie mogę znaleźć użytkownika.', ephemeral: true });
     }
     try {
       await member.ban();
-      message.channel.send(`Użytkownik ${member.user.tag} został zbanowany.`);
+      await interaction.reply(`Użytkownik ${member.user.tag} został zbanowany.`);
     } catch (err) {
       console.error(err);
-      message.reply('Nie udało się zbanować użytkownika.');
+      interaction.reply({ content: 'Nie udało się zbanować użytkownika.', ephemeral: true });
     }
   }
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,8 +1,13 @@
+const { SlashCommandBuilder } = require('discord.js');
+
 module.exports = {
-  name: 'help',
-  description: 'Wyświetla listę komend',
-  execute(message) {
-    const commands = message.client.commands.map(cmd => `**!${cmd.name}** - ${cmd.description}`).join('\n');
-    message.channel.send(`Dostępne komendy:\n${commands}`);
+  data: new SlashCommandBuilder()
+    .setName('help')
+    .setDescription('Wyświetla listę komend'),
+  async execute(interaction) {
+    const commands = interaction.client.commands
+      .map(cmd => `**/${cmd.data.name}** - ${cmd.data.description}`)
+      .join('\n');
+    await interaction.reply(`Dostępne komendy:\n${commands}`);
   }
 };

--- a/commands/kick.js
+++ b/commands/kick.js
@@ -1,22 +1,28 @@
-const { PermissionsBitField } = require('discord.js');
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
 
 module.exports = {
-  name: 'kick',
-  description: 'Wyrzuca wskazanego użytkownika z serwera',
-  async execute(message) {
-    if (!message.member.permissions.has(PermissionsBitField.Flags.KickMembers)) {
-      return message.reply('Nie masz uprawnień do wyrzucania użytkowników.');
+  data: new SlashCommandBuilder()
+    .setName('kick')
+    .setDescription('Wyrzuca wskazanego użytkownika z serwera')
+    .addUserOption(option =>
+      option.setName('uzytkownik')
+        .setDescription('Użytkownik do wyrzucenia')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionsBitField.Flags.KickMembers)) {
+      return interaction.reply({ content: 'Nie masz uprawnień do wyrzucania użytkowników.', ephemeral: true });
     }
-    const member = message.mentions.members.first();
+    const member = interaction.options.getMember('uzytkownik');
     if (!member) {
-      return message.reply('Oznacz użytkownika do wyrzucenia.');
+      return interaction.reply({ content: 'Nie mogę znaleźć użytkownika.', ephemeral: true });
     }
     try {
       await member.kick();
-      message.channel.send(`Użytkownik ${member.user.tag} został wyrzucony.`);
+      await interaction.reply(`Użytkownik ${member.user.tag} został wyrzucony.`);
     } catch (err) {
       console.error(err);
-      message.reply('Nie udało się wyrzucić użytkownika.');
+      interaction.reply({ content: 'Nie udało się wyrzucić użytkownika.', ephemeral: true });
     }
   }
 };

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,7 +1,10 @@
+const { SlashCommandBuilder } = require('discord.js');
+
 module.exports = {
-  name: 'ping',
-  description: 'Sprawdź czy bot działa',
-  execute(message) {
-    message.reply('Pong!');
+  data: new SlashCommandBuilder()
+    .setName('ping')
+    .setDescription('Sprawdź czy bot działa'),
+  async execute(interaction) {
+    await interaction.reply('Pong!');
   }
 };

--- a/commands/poll.js
+++ b/commands/poll.js
@@ -1,12 +1,17 @@
+const { SlashCommandBuilder } = require('discord.js');
+
 module.exports = {
-  name: 'poll',
-  description: 'Tworzy prostą ankietę z reakcjami 👍 i 👎',
-  async execute(message, args) {
-    if (!args.length) {
-      return message.reply('Podaj treść ankiety.');
-    }
-    const question = args.join(' ');
-    const pollMessage = await message.channel.send(`\uD83D\uDCCA **${question}**`);
+  data: new SlashCommandBuilder()
+    .setName('poll')
+    .setDescription('Tworzy prostą ankietę z reakcjami 👍 i 👎')
+    .addStringOption(option =>
+      option.setName('pytanie')
+        .setDescription('Treść ankiety')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    const question = interaction.options.getString('pytanie');
+    const pollMessage = await interaction.reply({ content: `\uD83D\uDCCA **${question}**`, fetchReply: true });
     await pollMessage.react('👍');
     await pollMessage.react('👎');
   }

--- a/commands/siema.js
+++ b/commands/siema.js
@@ -1,7 +1,10 @@
+const { SlashCommandBuilder } = require('discord.js');
+
 module.exports = {
-  name: 'siema',
-  description: 'Przywitaj się z botem',
-  execute(message) {
-    message.reply('Siemano, co tam wariacie?');
+  data: new SlashCommandBuilder()
+    .setName('siema')
+    .setDescription('Przywitaj się z botem'),
+  async execute(interaction) {
+    await interaction.reply('Siemano, co tam wariacie?');
   }
 };

--- a/commands/userinfo.js
+++ b/commands/userinfo.js
@@ -1,9 +1,17 @@
+const { SlashCommandBuilder } = require('discord.js');
+
 module.exports = {
-  name: 'userinfo',
-  description: 'Wyświetla informacje o użytkowniku',
-  execute(message) {
-    const user = message.author;
-    const member = message.guild.members.cache.get(user.id);
+  data: new SlashCommandBuilder()
+    .setName('userinfo')
+    .setDescription('Wyświetla informacje o użytkowniku')
+    .addUserOption(option =>
+      option.setName('uzytkownik')
+        .setDescription('Użytkownik, o którym chcesz uzyskać informacje')
+        .setRequired(false)
+    ),
+  async execute(interaction) {
+    const user = interaction.options.getUser('uzytkownik') || interaction.user;
+    const member = interaction.guild.members.cache.get(user.id);
     const embed = {
       color: 0x0099ff,
       title: user.tag,
@@ -13,6 +21,6 @@ module.exports = {
         { name: 'Utworzone konto', value: user.createdAt.toDateString(), inline: true }
       ]
     };
-    message.channel.send({ embeds: [embed] });
+    await interaction.reply({ embeds: [embed] });
   }
 };

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,0 +1,40 @@
+// Register slash commands with Discord
+require('dotenv').config();
+
+const { REST, Routes } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+
+const commands = [];
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+for (const file of commandFiles) {
+  const command = require(path.join(commandsPath, file));
+  if (command && command.data) {
+    commands.push(command.data.toJSON());
+  }
+}
+
+const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
+
+(async () => {
+  try {
+    console.log(`🚀 Reloading ${commands.length} application (/) commands.`);
+
+    if (process.env.GUILD_ID) {
+      await rest.put(
+        Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID),
+        { body: commands },
+      );
+      console.log('✅ Successfully reloaded guild application commands.');
+    } else {
+      await rest.put(
+        Routes.applicationCommands(process.env.CLIENT_ID),
+        { body: commands },
+      );
+      console.log('✅ Successfully reloaded global application commands.');
+    }
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/index.js
+++ b/index.js
@@ -6,45 +6,38 @@ const fs = require('fs');
 const path = require('path');
 
 const client = new Client({
-  intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMessages,
-    GatewayIntentBits.GuildMembers,
-    GatewayIntentBits.MessageContent
-  ],
+  intents: [GatewayIntentBits.Guilds],
   partials: [Partials.Channel]
 });
 
 client.commands = new Collection();
-const prefix = '!';
 
 const commandsPath = path.join(__dirname, 'commands');
-fs.readdirSync(commandsPath).forEach(file => {
-  if (file.endsWith('.js')) {
-    const command = require(path.join(commandsPath, file));
-    if (command && command.name && command.execute) {
-      client.commands.set(command.name, command);
-    }
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+for (const file of commandFiles) {
+  const command = require(path.join(commandsPath, file));
+  if (command && command.data && command.execute) {
+    client.commands.set(command.data.name, command);
   }
-});
+}
 
 client.once('ready', () => {
   console.log(`✅ Logged in as ${client.user.tag}`);
 });
 
-client.on('messageCreate', async message => {
-  if (!message.content.startsWith(prefix) || message.author.bot) return;
-  const args = message.content.slice(prefix.length).trim().split(/ +/);
-  const commandName = args.shift().toLowerCase();
-
-  const command = client.commands.get(commandName);
+client.on('interactionCreate', async interaction => {
+  if (!interaction.isChatInputCommand()) return;
+  const command = client.commands.get(interaction.commandName);
   if (!command) return;
-
   try {
-    await command.execute(message, args);
+    await command.execute(interaction);
   } catch (error) {
     console.error(error);
-    message.reply('❌ Wystąpił błąd podczas wykonywania komendy.');
+    if (interaction.replied || interaction.deferred) {
+      interaction.followUp({ content: '❌ Wystąpił błąd podczas wykonywania komendy.', ephemeral: true });
+    } else {
+      interaction.reply({ content: '❌ Wystąpił błąd podczas wykonywania komendy.', ephemeral: true });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- rewrite command handlers to use Discord slash commands
- add script for registering slash commands

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684abe0cad0483259dea13d0441b463e