### PR TITLE
Add Discord OAuth web dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cookie-parser": "^1.4.6",
         "discord.js": "^14.19.3",
         "dotenv": "^16.5.0",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "express-session": "^1.18.0"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -313,6 +315,28 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -514,6 +538,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -808,6 +866,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -849,6 +916,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -1074,6 +1150,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "discord.js": "^14.19.3",
     "dotenv": "^16.5.0",
     "express": "^4.19.2",
-    "cookie-parser": "^1.4.6"
+    "cookie-parser": "^1.4.6",
+    "express-session": "^1.18.0"
   }
 }

--- a/web/admin.html
+++ b/web/admin.html
@@ -9,21 +9,64 @@
     .glass { background: rgba(255,255,255,0.1); backdrop-filter: blur(20px); border-radius: 1rem; border: 1px solid rgba(255,255,255,0.3); box-shadow: 0 4px 30px rgba(0,0,0,0.1); }
   </style>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    async function fetchJSON(url) {
+      const r = await fetch(url);
+      return r.ok ? r.json() : [];
+    }
+    document.addEventListener('DOMContentLoaded', async () => {
       const saved = localStorage.getItem('accent') || '#14b8a6';
       document.documentElement.style.setProperty('--accent', saved);
+
+      const guildSelect = document.getElementById('guild');
+      const channelSelect = document.getElementById('channel');
+      const form = document.getElementById('msgForm');
+      const guilds = await fetchJSON('/guilds');
+      guilds.forEach(g => {
+        const opt = document.createElement('option');
+        opt.value = g.id;
+        opt.textContent = g.name;
+        guildSelect.appendChild(opt);
+      });
+      guildSelect.addEventListener('change', async () => {
+        channelSelect.innerHTML = '';
+        const channels = await fetchJSON(`/channels/${guildSelect.value}`);
+        channels.forEach(c => {
+          const opt = document.createElement('option');
+          opt.value = c.id;
+          opt.textContent = c.name;
+          channelSelect.appendChild(opt);
+        });
+      });
+      guildSelect.dispatchEvent(new Event('change'));
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const body = {
+          channelId: channelSelect.value,
+          message: document.getElementById('message').value
+        };
+        const res = await fetch('/message', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+        alert(await res.text());
+      });
     });
   </script>
 </head>
 <body class="min-h-screen flex items-center justify-center p-4" style="--accent:#14b8a6;">
   <div class="glass p-8 max-w-lg w-full text-white">
     <h1 class="text-2xl font-bold mb-4 text-center text-[var(--accent)]">Admin Zone</h1>
-    <form method="POST" action="/message" class="space-y-4">
+    <form id="msgForm" class="space-y-4">
       <div>
-        <input type="text" name="channelId" placeholder="Channel ID" class="w-full px-3 py-2 rounded" required>
+        <select id="guild" class="w-full text-black px-3 py-2 rounded"></select>
       </div>
       <div>
-        <input type="text" name="message" placeholder="Message" class="w-full px-3 py-2 rounded" required>
+        <select id="channel" class="w-full text-black px-3 py-2 rounded"></select>
+      </div>
+      <div>
+        <input type="text" id="message" placeholder="Message" class="w-full px-3 py-2 rounded text-black" required>
       </div>
       <button class="w-full py-2 bg-[var(--accent)] text-white rounded">Send</button>
     </form>

--- a/web/index.html
+++ b/web/index.html
@@ -25,10 +25,7 @@
 <body class="min-h-screen flex items-center justify-center p-4" style="--accent:#14b8a6;">
   <div class="glass p-8 max-w-md w-full text-center text-white">
     <h1 class="text-2xl font-bold mb-4 text-[var(--accent)]">MODSN.AI Panel</h1>
-    <form method="POST" action="/login" class="space-y-4">
-      <input type="password" name="token" placeholder="Access token" class="w-full px-3 py-2 rounded" required>
-      <button class="w-full py-2 bg-[var(--accent)] text-white rounded">Login</button>
-    </form>
+    <a href="/login" class="block w-full py-2 bg-[var(--accent)] text-white rounded">Login with Discord</a>
     <div class="mt-4 flex items-center justify-between">
       <label class="text-sm">Accent color</label>
       <input type="color" id="color" class="rounded border-0">


### PR DESCRIPTION
## Summary
- integrate `express-session`
- add Discord OAuth login flow
- provide server and channel selection in admin page
- update login page to use Discord authentication

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ac74a23a48325a4e42cd864e8c1e0