### PR TITLE
Add server selection page and improved UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "discord.js": "^14.19.3",
         "dotenv": "^16.5.0",
         "express": "^4.19.2",
-        "express-session": "^1.18.0"
+        "express-session": "^1.18.0",
+        "helmet": "^8.1.0"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -695,6 +696,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.5.0",
     "express": "^4.19.2",
     "cookie-parser": "^1.4.6",
-    "express-session": "^1.18.0"
+    "express-session": "^1.18.0",
+    "helmet": "^8.1.0"
   }
 }

--- a/web/admin.html
+++ b/web/admin.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Admin Zone</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <script>
     async function fetchJSON(url) {
@@ -10,12 +11,18 @@
       return r.ok ? r.json() : [];
     }
     document.addEventListener('DOMContentLoaded', async () => {
-      const saved = localStorage.getItem('accent') || '#14b8a6';
-      document.documentElement.style.setProperty('--accent', saved);
+      const user = await fetchJSON('/me');
+      document.getElementById('username').textContent = user.username;
+      document.getElementById('avatar').src = `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`;
+
+      const stats = await fetchJSON('/stats');
+      document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
 
       const guildSelect = document.getElementById('guild');
       const channelSelect = document.getElementById('channel');
       const form = document.getElementById('msgForm');
+      const params = new URLSearchParams(window.location.search);
+      const pre = params.get('guildId');
       const guilds = await fetchJSON('/guilds');
       guilds.forEach(g => {
         const opt = document.createElement('option');
@@ -23,6 +30,7 @@
         opt.textContent = g.name;
         guildSelect.appendChild(opt);
       });
+      if (pre) guildSelect.value = pre;
       guildSelect.addEventListener('change', async () => {
         channelSelect.innerHTML = '';
         const channels = await fetchJSON(`/channels/${guildSelect.value}`);
@@ -47,29 +55,42 @@
           body: JSON.stringify(body)
         });
         alert(await res.text());
+        form.reset();
       });
     });
   </script>
 </head>
-<body style="--accent:#14b8a6;">
-  <div class="glass card">
-    <h1>Admin Zone</h1>
-    <form id="msgForm">
-      <div class="form-group">
-        <label>Guild</label>
-        <select id="guild"></select>
-      </div>
-      <div class="form-group">
-        <label>Channel</label>
-        <select id="channel"></select>
-      </div>
-      <div class="form-group">
-        <label>Message</label>
-        <input type="text" id="message" required>
-      </div>
-      <button class="btn" style="margin-top:1rem;">Send</button>
-    </form>
-    <a href="/logout" class="link">Logout</a>
+<body>
+  <div class="sidebar">
+    <div class="user-info">
+      <img id="avatar" class="avatar" src="" alt="avatar">
+      <div id="username"></div>
+      <p id="stats"></p>
+    </div>
+    <nav>
+      <a href="servers.html" class="link">Servers</a>
+      <a href="/logout" class="link">Logout</a>
+    </nav>
   </div>
+  <main class="main">
+    <div class="glass card">
+      <h1>Admin Zone</h1>
+      <form id="msgForm">
+        <div class="form-group">
+          <label>Guild</label>
+          <select id="guild"></select>
+        </div>
+        <div class="form-group">
+          <label>Channel</label>
+          <select id="channel"></select>
+        </div>
+        <div class="form-group">
+          <label>Message</label>
+          <input type="text" id="message" required>
+        </div>
+        <button class="btn" style="margin-top:1rem;">Send</button>
+      </form>
+    </div>
+  </main>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -3,29 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <title>MODSN.AI Panel</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const colorInput = document.getElementById('color');
-      const root = document.documentElement;
-      const saved = localStorage.getItem('accent') || '#14b8a6';
-      root.style.setProperty('--accent', saved);
-      colorInput.value = saved;
-      colorInput.addEventListener('input', () => {
-        root.style.setProperty('--accent', colorInput.value);
-        localStorage.setItem('accent', colorInput.value);
-      });
-    });
-  </script>
 </head>
-<body style="--accent:#14b8a6;">
-  <div class="glass card">
-    <h1>MODSN.AI Panel</h1>
-    <a href="/login" class="btn">Login with Discord</a>
-    <div class="form-group">
-      <label>Accent color</label>
-      <input type="color" id="color">
+  <body>
+    <div class="glass card">
+      <h1>MODSN.AI Panel</h1>
+      <a href="/login" class="btn">Login with Discord</a>
     </div>
-  </div>
 </body>
 </html>

--- a/web/servers.html
+++ b/web/servers.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Select Server</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <script>
+    async function fetchJSON(url){const r=await fetch(url);return r.ok? r.json():[];}
+    document.addEventListener('DOMContentLoaded',async()=>{
+      const user=await fetchJSON('/me');
+      document.getElementById('username').textContent=user.username;
+      document.getElementById('avatar').src=`https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`;
+
+      const stats = await fetchJSON('/stats');
+      document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
+
+      const list=document.getElementById('guilds');
+      const guilds=await fetchJSON('/guilds');
+      guilds.forEach(g=>{
+        const li=document.createElement('li');
+        const link=document.createElement('a');
+        link.textContent=g.name;
+        link.href=`admin.html?guildId=${g.id}`;
+        li.appendChild(link);
+        list.appendChild(li);
+      });
+    });
+  </script>
+</head>
+<body>
+  <div class="sidebar">
+    <div class="user-info">
+      <img id="avatar" class="avatar" src="" alt="avatar">
+      <div id="username"></div>
+      <p id="stats"></p>
+    </div>
+    <nav>
+      <a href="/logout" class="link">Logout</a>
+    </nav>
+  </div>
+  <main class="main">
+    <div class="glass card">
+      <h1>Select server</h1>
+      <ul id="guilds"></ul>
+    </div>
+  </main>
+</body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13,13 +13,13 @@
 
 body {
   margin: 0;
-  font-family: system-ui, sans-serif;
+  font-family: 'Poppins', system-ui, sans-serif;
   background: radial-gradient(circle at top left, #1f2937 0%, #000 100%);
   color: var(--text);
   min-height: 100vh;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
+  justify-content: flex-start;
   padding: 1rem;
 }
 
@@ -55,7 +55,7 @@ h1 {
   display: block;
   width: 100%;
   text-align: center;
-  transition: filter .2s;
+  transition: filter .2s, background-color .3s;
 }
 
 .btn:hover {
@@ -91,4 +91,40 @@ select {
 
 .link:hover {
   color: var(--accent);
+}
+
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  width: 220px;
+  background: var(--bg-secondary);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: transform .3s ease;
+}
+
+.main {
+  margin-left: 220px;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  transition: margin-left .3s ease;
+}
+
+.avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  margin-bottom: .5rem;
+}
+
+.user-info {
+  text-align: center;
+  margin-bottom: 2rem;
 }

--- a/web/user.html
+++ b/web/user.html
@@ -3,27 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <title>User Zone</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const colorInput = document.getElementById('color');
-      const saved = localStorage.getItem('accent') || '#14b8a6';
-      document.documentElement.style.setProperty('--accent', saved);
-      colorInput.value = saved;
-      colorInput.addEventListener('input', () => {
-        document.documentElement.style.setProperty('--accent', colorInput.value);
-        localStorage.setItem('accent', colorInput.value);
-      });
+    async function fetchJSON(url){const r=await fetch(url);return r.ok? r.json():[];}
+    document.addEventListener('DOMContentLoaded', async () => {
+      const user=await fetchJSON('/me');
+      document.getElementById('username').textContent = user.username;
+      document.getElementById('avatar').src = `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`;
     });
   </script>
 </head>
-<body style="--accent:#14b8a6;">
+<body>
   <div class="glass card">
     <h1>User Zone</h1>
-    <div class="form-group">
-      <label>Accent color</label>
-      <input type="color" id="color">
-    </div>
+    <img id="avatar" class="avatar" src="" alt="avatar">
+    <p id="username"></p>
     <a href="/logout" class="link">Logout</a>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- include `helmet` middleware for security
- fetch user info during OAuth callback
- add `/me` and `/stats` endpoints
- validate messages before sending
- create new server selection page with sidebar
- show user avatar and stats on admin and server pages
- add Poppins font, sidebar layout, and transitions

## Testing
- `npm install --silent`
- `npm test` *(fails: Error: no test specified)*
- `node index.js` *(fails: TokenInvalid)*

------
https://chatgpt.com/codex/tasks/task_e_684acb05fd188325815e7d03301415fe