### PR TITLE
Fix session handling for Discord OAuth

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -19,7 +19,7 @@ module.exports = function startWebServer(client) {
   app.use(express.json());
 
   // Cookie parser MUST come before the session middleware
-  app.use(cookieParser());
+  app.use(cookieParser(process.env.SESSION_SECRET));
   app.use(helmet());
 
   app.use(
@@ -28,7 +28,8 @@ module.exports = function startWebServer(client) {
       resave: false,
       saveUninitialized: false,
       cookie: {
-        sameSite: 'lax'
+        sameSite: 'lax',
+        secure: false
       }
     })
   );


### PR DESCRIPTION
## Summary
- ensure `cookie-parser` uses the same secret as `express-session`
- mark the session cookie with `secure: false`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ad7be2eb08325b8952e36f4140c19