### PR TITLE
Add invite link and improve styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ node index.js
 ```
 
 Aplikacja wystartuje na porcie `3000`. Otwórz `http://localhost:3000` w przeglądarce i zaloguj się przez Discord.
+Jeżeli bot nie jest jeszcze na Twoim serwerze, skorzystaj z adresu `http://localhost:3000/invite` aby go dodać.
 
 ## Testy
 

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,7 @@
       <h1>Welcome to MODSN.AI</h1>
       <p>Manage your Discord servers with ease.</p>
       <a href="/login" class="btn">Login with Discord</a>
+      <a href="/invite" class="btn" style="margin-left:0.5rem;">Invite Bot</a>
     </div>
   </section>
   <footer class="footer">Panel MODSN.AI &copy; 2024</footer>

--- a/web/server.js
+++ b/web/server.js
@@ -29,11 +29,22 @@ module.exports = function startWebServer(client) {
       saveUninitialized: false,
       cookie: {
         sameSite: 'lax',
-        secure: false
+        httpOnly: true,
+        maxAge: 24 * 60 * 60 * 1000,
+        secure: process.env.NODE_ENV === 'production'
       }
     })
   );
   app.use(express.static(path.join(__dirname)));
+
+  app.get('/invite', (req, res) => {
+    const params = new URLSearchParams({
+      client_id: CLIENT_ID,
+      permissions: '8',
+      scope: 'bot'
+    });
+    res.redirect(`https://discord.com/oauth2/authorize?${params.toString()}`);
+  });
 
   app.get('/login', (req, res) => {
     const state = crypto.randomBytes(16).toString('hex');

--- a/web/servers.js
+++ b/web/servers.js
@@ -25,8 +25,5 @@ document.addEventListener('DOMContentLoaded', async () => {
     li.appendChild(link);
     list.appendChild(li);
   });
-  if (guilds.length === 0) {
-    invite.innerHTML =
-      '<a class="btn" href="https://discord.com/oauth2/authorize?client_id=1382682041283510272&permissions=8&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&integration_type=0&scope=identify+guilds+guilds.channels.read+bot">Add Bot to Server</a>';
-  }
+  invite.innerHTML = '<a class="btn" href="/invite">Add Bot to Server</a>';
 });

--- a/web/styles.css
+++ b/web/styles.css
@@ -125,6 +125,25 @@ body {
   color: var(--violet);
 }
 
+.form-group {
+  margin-bottom: 1rem;
+  text-align: left;
+  width: 100%;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.form-group input,
+.form-group select {
+  width: 100%;
+  padding: 0.5rem;
+  border: none;
+  border-radius: 0.25rem;
+}
+
 ul { list-style: none; padding: 0; margin: 0; }
 ul li { margin: 0.5rem 0; }
 ul li a { color: var(--text); text-decoration: none; padding: 0.5rem; display: block; border-radius: 0.25rem; transition: background 0.3s; }


### PR DESCRIPTION
## Summary
- allow inviting the bot through `/invite` endpoint
- show invite button on landing page and server list
- persist session cookies longer and mark them httpOnly
- style form fields
- document invite route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684adc28b6a88325a168a5739f8438b1