### PR TITLE
Improve error handling in web panel

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -8,18 +8,25 @@
   <script>
     async function fetchJSON(url) {
       const r = await fetch(url, { credentials: 'include' });
-      return r.ok ? r.json() : {};
+      if (!r.ok) {
+        console.error('Failed to fetch', url, r.status);
+        return null;
+      }
+      return r.json();
     }
     document.addEventListener('DOMContentLoaded', async () => {
       const user = await fetchJSON('/me');
-      document.getElementById('username').textContent = user.username;
-      const avatarUrl = user.avatar
-        ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
-        : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator)||0)%5}.png`;
-      document.getElementById('avatar').src = avatarUrl;
+      if (user) {
+        document.getElementById('username').textContent = user.username;
+        const avatarUrl = user.avatar
+          ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
+          : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator) || 0) % 5}.png`;
+        document.getElementById('avatar').src = avatarUrl;
+      }
 
       const stats = await fetchJSON('/stats');
-      document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
+      if (stats)
+        document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
 
       const guildSelect = document.getElementById('guild');
       const channelSelect = document.getElementById('channel');
@@ -27,22 +34,24 @@
       const params = new URLSearchParams(window.location.search);
       const pre = params.get('guildId');
       const guilds = await fetchJSON('/guilds');
-      guilds.forEach(g => {
-        const opt = document.createElement('option');
-        opt.value = g.id;
-        opt.textContent = g.name;
-        guildSelect.appendChild(opt);
-      });
+      if (guilds)
+        guilds.forEach(g => {
+          const opt = document.createElement('option');
+          opt.value = g.id;
+          opt.textContent = g.name;
+          guildSelect.appendChild(opt);
+        });
       if (pre) guildSelect.value = pre;
       guildSelect.addEventListener('change', async () => {
         channelSelect.innerHTML = '';
         const channels = await fetchJSON(`/channels/${guildSelect.value}`);
-        channels.forEach(c => {
-          const opt = document.createElement('option');
-          opt.value = c.id;
-          opt.textContent = c.name;
-          channelSelect.appendChild(opt);
-        });
+        if (channels)
+          channels.forEach(c => {
+            const opt = document.createElement('option');
+            opt.value = c.id;
+            opt.textContent = c.name;
+            channelSelect.appendChild(opt);
+          });
       });
       guildSelect.dispatchEvent(new Event('change'));
 

--- a/web/server.js
+++ b/web/server.js
@@ -149,11 +149,15 @@ module.exports = function startWebServer(client) {
   app.get('/channels/:guildId', requireAuth, async (req, res) => {
     const guild = client.guilds.cache.get(req.params.guildId);
     if (!guild) return res.status(404).send('Guild not found');
-    await guild.channels.fetch();
-    const channels = guild.channels.cache
-      .filter(ch => ch.isTextBased())
-      .map(ch => ({ id: ch.id, name: ch.name }));
-    res.json(channels);
+    try {
+      const channels = (await guild.channels.fetch())
+        .filter(ch => ch.isTextBased())
+        .map(ch => ({ id: ch.id, name: ch.name }));
+      res.json(channels);
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Failed to fetch channels');
+    }
   });
 
   app.post('/message', requireAuth, async (req, res) => {

--- a/web/servers.html
+++ b/web/servers.html
@@ -8,32 +8,41 @@
   <script>
     async function fetchJSON(url){
       const r=await fetch(url,{credentials:'include'});
-      return r.ok? r.json():{};
+      if(!r.ok){
+        console.error('Failed to fetch',url,r.status);
+        return null;
+      }
+      return r.json();
     }
     document.addEventListener('DOMContentLoaded',async()=>{
       const user=await fetchJSON('/me');
-      document.getElementById('username').textContent=user.username;
-      const avatarUrl = user.avatar
-        ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
-        : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator)||0)%5}.png`;
-      document.getElementById('avatar').src = avatarUrl;
+      if(user){
+        document.getElementById('username').textContent=user.username;
+        const avatarUrl = user.avatar
+          ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
+          : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator)||0)%5}.png`;
+        document.getElementById('avatar').src = avatarUrl;
+      }
 
       const stats = await fetchJSON('/stats');
-      document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
+      if(stats)
+        document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
 
       const list=document.getElementById('guilds');
       const invite=document.getElementById('invite');
       const guilds=await fetchJSON('/guilds');
-      guilds.forEach(g=>{
-        const li=document.createElement('li');
-        const link=document.createElement('a');
-        link.textContent=g.name;
-        link.href=`admin.html?guildId=${g.id}`;
-        li.appendChild(link);
-        list.appendChild(li);
-      });
-      if(guilds.length===0){
-        invite.innerHTML='<a class="btn" href="https://discord.com/oauth2/authorize?client_id=1382682041283510272&permissions=8&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&integration_type=0&scope=identify+guilds+bot">Add Bot to Server</a>';
+      if(guilds){
+        guilds.forEach(g=>{
+          const li=document.createElement('li');
+          const link=document.createElement('a');
+          link.textContent=g.name;
+          link.href=`admin.html?guildId=${g.id}`;
+          li.appendChild(link);
+          list.appendChild(li);
+        });
+        if(guilds.length===0){
+          invite.innerHTML='<a class="btn" href="https://discord.com/oauth2/authorize?client_id=1382682041283510272&permissions=8&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&integration_type=0&scope=identify+guilds+bot">Add Bot to Server</a>';
+        }
       }
     });
   </script>

--- a/web/servers.js
+++ b/web/servers.js
@@ -1,29 +1,38 @@
 async function fetchJSON(url) {
   const r = await fetch(url, { credentials: 'include' });
-  return r.ok ? r.json() : {};
+  if (!r.ok) {
+    console.error('Failed to fetch', url, r.status);
+    return null;
+  }
+  return r.json();
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
   const user = await fetchJSON('/me');
-  document.getElementById('username').textContent = user.username;
-  const avatarUrl = user.avatar
-    ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
-    : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator) || 0) % 5}.png`;
-  document.getElementById('avatar').src = avatarUrl;
+  if (user) {
+    document.getElementById('username').textContent = user.username;
+    const avatarUrl = user.avatar
+      ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
+      : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator) || 0) % 5}.png`;
+    document.getElementById('avatar').src = avatarUrl;
+  }
 
   const stats = await fetchJSON('/stats');
-  document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
+  if (stats)
+    document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
 
   const list = document.getElementById('guilds');
   const invite = document.getElementById('invite');
   const guilds = await fetchJSON('/guilds');
-  guilds.forEach(g => {
-    const li = document.createElement('li');
-    const link = document.createElement('a');
-    link.textContent = g.name;
-    link.href = `admin.html?guildId=${g.id}`;
-    li.appendChild(link);
-    list.appendChild(li);
-  });
-  invite.innerHTML = '<a class="btn" href="/invite">Add Bot to Server</a>';
+  if (guilds) {
+    guilds.forEach(g => {
+      const li = document.createElement('li');
+      const link = document.createElement('a');
+      link.textContent = g.name;
+      link.href = `admin.html?guildId=${g.id}`;
+      li.appendChild(link);
+      list.appendChild(li);
+    });
+    invite.innerHTML = '<a class="btn" href="/invite">Add Bot to Server</a>';
+  }
 });

--- a/web/user.html
+++ b/web/user.html
@@ -8,15 +8,21 @@
   <script>
     async function fetchJSON(url){
       const r=await fetch(url,{credentials:'include'});
-      return r.ok? r.json():{};
+      if(!r.ok){
+        console.error('Failed to fetch',url,r.status);
+        return null;
+      }
+      return r.json();
     }
     document.addEventListener('DOMContentLoaded', async () => {
       const user=await fetchJSON('/me');
-      document.getElementById('username').textContent = user.username;
-      const avatarUrl = user.avatar
-        ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
-        : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator)||0)%5}.png`;
-      document.getElementById('avatar').src = avatarUrl;
+      if(user){
+        document.getElementById('username').textContent = user.username;
+        const avatarUrl = user.avatar
+          ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
+          : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator)||0)%5}.png`;
+        document.getElementById('avatar').src = avatarUrl;
+      }
     });
   </script>
 </head>


### PR DESCRIPTION
## Summary
- handle errors while fetching channels in the web server
- make `fetchJSON` report HTTP failures and guard against null data in the client-side pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684aded5f1dc832590d8d8bf0fb8843c