### PR TITLE
Improve web styling and session security

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -8,23 +8,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <script>
-    async function fetchJSON(url) {
-      const r = await fetch(url, { credentials: 'include' });
-      if (!r.ok) {
-        console.error('Failed to fetch', url, r.status);
-        return null;
-      }
-      return r.json();
-    }
     document.addEventListener('DOMContentLoaded', async () => {
-      const user = await fetchJSON('/me');
-      if (user) {
-        document.getElementById('username').textContent = user.username;
-        const avatarUrl = user.avatar
-          ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
-          : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator) || 0) % 5}.png`;
-        document.getElementById('avatar').src = avatarUrl;
-      }
+      const user = await loadUserInfo();
 
       const stats = await fetchJSON('/stats');
       if (stats)

--- a/web/script.js
+++ b/web/script.js
@@ -1,3 +1,30 @@
+async function fetchJSON(url, opts = {}) {
+  const res = await fetch(url, { credentials: 'include', ...opts });
+  if (!res.ok) throw new Error(res.status);
+  return res.json();
+}
+
+async function loadUserInfo() {
+  try {
+    const user = await fetchJSON('/me');
+    const nameEl = document.getElementById('username');
+    const avatarEl = document.getElementById('avatar');
+    if (nameEl) nameEl.textContent = user.username;
+    if (avatarEl) {
+      const ext = user.avatar && user.avatar.startsWith('a_') ? 'gif' : 'png';
+      avatarEl.src = user.avatar
+        ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.${ext}?size=64`
+        : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator) || 0) % 5}.png`;
+    }
+    return user;
+  } catch (_) {
+    if (!['/', '/index.html'].includes(window.location.pathname)) {
+      window.location.replace('/');
+    }
+    return null;
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // 3D tilt effect
   document.querySelectorAll('.tilt').forEach(card => {

--- a/web/server.js
+++ b/web/server.js
@@ -36,12 +36,25 @@ module.exports = function startWebServer(client) {
       cookie: {
         sameSite: 'lax',
         httpOnly: true,
-        maxAge: 24 * 60 * 60 * 1000,
+        maxAge: 7 * 24 * 60 * 60 * 1000,
         secure: process.env.NODE_ENV === 'production'
       }
     })
   );
-  app.use(express.static(path.join(__dirname)));
+  const staticPath = path.join(__dirname);
+
+  function sendProtected(file) {
+    return (req, res) => {
+      res.set('Cache-Control', 'no-store');
+      res.sendFile(path.join(staticPath, file));
+    };
+  }
+
+  app.get('/servers.html', requireAuth, sendProtected('servers.html'));
+  app.get('/admin.html', requireAuth, sendProtected('admin.html'));
+  app.get('/user.html', requireAuth, sendProtected('user.html'));
+
+  app.use(express.static(staticPath));
 
   app.get('/invite', (req, res) => {
     const params = new URLSearchParams({

--- a/web/servers.html
+++ b/web/servers.html
@@ -7,47 +7,6 @@
   <title>Select Server</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
-  <script>
-    async function fetchJSON(url){
-      const r=await fetch(url,{credentials:'include'});
-      if(!r.ok){
-        console.error('Failed to fetch',url,r.status);
-        return null;
-      }
-      return r.json();
-    }
-    document.addEventListener('DOMContentLoaded',async()=>{
-      const user=await fetchJSON('/me');
-      if(user){
-        document.getElementById('username').textContent=user.username;
-        const avatarUrl = user.avatar
-          ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
-          : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator)||0)%5}.png`;
-        document.getElementById('avatar').src = avatarUrl;
-      }
-
-      const stats = await fetchJSON('/stats');
-      if(stats)
-        document.getElementById('stats').textContent = `Bot on ${stats.botGuilds} servers`;
-
-      const list=document.getElementById('guilds');
-      const invite=document.getElementById('invite');
-      const guilds=await fetchJSON('/guilds');
-      if(guilds){
-        guilds.forEach(g=>{
-          const li=document.createElement('li');
-          const link=document.createElement('a');
-          link.textContent=g.name;
-          link.href=`admin.html?guildId=${g.id}`;
-          li.appendChild(link);
-          list.appendChild(li);
-        });
-        if(guilds.length===0){
-          invite.innerHTML='<a class="btn" href="https://discord.com/oauth2/authorize?client_id=1382682041283510272&permissions=8&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&integration_type=0&scope=identify+guilds+bot">Add Bot to Server</a>';
-        }
-      }
-    });
-  </script>
 </head>
 <body>
   <header class="topbar">
@@ -74,6 +33,7 @@
     </div>
   </main>
   <footer class="footer">Panel MODSN.AI &copy; 2024</footer>
+  <script src="script.js"></script>
   <script src="servers.js"></script>
 </body>
 </html>

--- a/web/servers.js
+++ b/web/servers.js
@@ -1,21 +1,5 @@
-async function fetchJSON(url) {
-  const r = await fetch(url, { credentials: 'include' });
-  if (!r.ok) {
-    console.error('Failed to fetch', url, r.status);
-    return null;
-  }
-  return r.json();
-}
-
 document.addEventListener('DOMContentLoaded', async () => {
-  const user = await fetchJSON('/me');
-  if (user) {
-    document.getElementById('username').textContent = user.username;
-    const avatarUrl = user.avatar
-      ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
-      : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator) || 0) % 5}.png`;
-    document.getElementById('avatar').src = avatarUrl;
-  }
+  const user = await loadUserInfo();
 
   const stats = await fetchJSON('/stats');
   if (stats)

--- a/web/styles.css
+++ b/web/styles.css
@@ -15,11 +15,13 @@
 
 body {
   font-family: var(--font);
-  background: var(--bg);
+  background: linear-gradient(135deg, #1f1f1f, #000);
   color: var(--text);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
+  scroll-behavior: smooth;
 }
 
 .topbar {
@@ -27,15 +29,19 @@ body {
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(4px);
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px) saturate(180%);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .sidebar {
   width: 220px;
   padding: 1rem;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(4px);
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px) saturate(180%);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  border-right: 1px solid rgba(255, 255, 255, 0.2);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -47,15 +53,19 @@ body {
   display: flex;
   justify-content: center;
   align-items: flex-start;
+  gap: 2rem;
 }
 
 .card {
-  background: var(--card-bg);
+  background: rgba(255, 255, 255, 0.1);
   padding: 1.5rem;
   border-radius: 0.75rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(10px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   width: 100%;
   max-width: 480px;
+  transition: transform 0.3s ease;
 }
 
 .btn {
@@ -66,21 +76,25 @@ body {
   color: #fff;
   border-radius: 0.5rem;
   text-decoration: none;
-  transition: background 0.3s;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition: background 0.3s, transform 0.2s;
 }
 
 .btn:hover {
   background: var(--accent-alt);
+  transform: translateY(-2px);
 }
 
 .link {
   color: var(--accent);
   text-decoration: none;
   margin: 0.25rem 0;
+  transition: color 0.3s;
 }
 
 .link:hover {
   color: var(--accent-alt);
+  text-decoration: underline;
 }
 
 .avatar {
@@ -88,6 +102,25 @@ body {
   height: 64px;
   border-radius: 50%;
   margin-bottom: 0.5rem;
+}
+
+.hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6rem 2rem;
+  text-align: center;
+  overflow: hidden;
+}
+
+.parallax-bg {
+  position: absolute;
+  inset: 0;
+  background: url('https://images.unsplash.com/photo-1504805572947-34fad45aed93?auto=compress&cs=tinysrgb&w=1920') center/cover no-repeat;
+  transform: translateZ(0);
+  will-change: transform;
+  z-index: -1;
 }
 
 .form-group {
@@ -133,10 +166,28 @@ ul li a:hover {
   padding: 1rem;
   opacity: 0.8;
   margin-top: auto;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
 }
 
 @media (max-width: 768px) {
   .sidebar {
     width: 180px;
+  }
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn 0.6s forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/web/user.html
+++ b/web/user.html
@@ -8,23 +8,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <script>
-    async function fetchJSON(url){
-      const r=await fetch(url,{credentials:'include'});
-      if(!r.ok){
-        console.error('Failed to fetch',url,r.status);
-        return null;
-      }
-      return r.json();
-    }
     document.addEventListener('DOMContentLoaded', async () => {
-      const user=await fetchJSON('/me');
-      if(user){
-        document.getElementById('username').textContent = user.username;
-        const avatarUrl = user.avatar
-          ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png?size=64`
-          : `https://cdn.discordapp.com/embed/avatars/${(parseInt(user.discriminator)||0)%5}.png`;
-        document.getElementById('avatar').src = avatarUrl;
-      }
+      await loadUserInfo();
     });
   </script>
 </head>


### PR DESCRIPTION
## Summary
- add glassmorphism UI and parallax styles
- fetch user info via new `loadUserInfo` helper
- protect HTML pages with session check and no-cache headers
- extend session lifespan and redirect unauthenticated users

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ae48abc548325acb21362902e3b59