### PR TITLE
Fix avatar display in web UI

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -22,6 +22,7 @@ module.exports = function startWebServer(client) {
   app.use(cookieParser(process.env.SESSION_SECRET));
   const csp = helmet.contentSecurityPolicy.getDefaultDirectives();
   csp["script-src"].push("'unsafe-inline'");
+  csp["img-src"].push('https://cdn.discordapp.com');
   app.use(
     helmet({
       contentSecurityPolicy: { directives: csp }


### PR DESCRIPTION
## Summary
- add Discord CDN to CSP img-src so avatars load

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ae80a038883258aef59bec9dc65d9