### PR TITLE
Remove CSS/JS animations

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -26,27 +26,5 @@ async function loadUserInfo() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  // 3D tilt effect
-  document.querySelectorAll('.tilt').forEach(card => {
-    card.addEventListener('mousemove', e => {
-      const rect = card.getBoundingClientRect();
-      const x = e.clientX - rect.left - rect.width / 2;
-      const y = e.clientY - rect.top - rect.height / 2;
-      const rotateX = (y / rect.height) * -15;
-      const rotateY = (x / rect.width) * 15;
-      card.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
-    });
-    card.addEventListener('mouseleave', () => {
-      card.style.transform = 'rotateX(0deg) rotateY(0deg)';
-    });
-  });
-
-  // parallax scrolling
-  window.addEventListener('scroll', () => {
-    document.querySelectorAll('.parallax').forEach(el => {
-      const speed = parseFloat(el.dataset.speed || '0.5');
-      const offset = window.scrollY * speed;
-      el.style.transform = `translateY(${offset}px)`;
-    });
-  });
+  // no animations
 });

--- a/web/styles.css
+++ b/web/styles.css
@@ -204,16 +204,6 @@ body.no-sidebar {
   padding-bottom: 0.75rem;
 }
 
-.card h1::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 60px;
-  height: 3px;
-  background-color: var(--primary);
-  border-radius: var(--radius-full);
-}
 
 /* Links */
 .link {
@@ -424,33 +414,6 @@ body.no-sidebar {
   display: flex;
   gap: 1rem;
   justify-content: center;
-}
-
-/* Tilt effect */
-.tilt {
-  transition: transform var(--transition-normal), box-shadow var(--transition-normal);
-  will-change: transform;
-}
-
-/* Animations */
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.fade-in {
-  opacity: 0;
-  animation: fadeIn 0.6s var(--transition-slow) forwards;
-}
-
-@keyframes pulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.03); }
-  100% { transform: scale(1); }
-}
-
-.pulse {
-  animation: pulse 2s infinite;
 }
 
 /* Utility classes */


### PR DESCRIPTION
## Summary
- remove decorative line on card headings
- strip tilt, fade, and pulse effects from styles
- delete JS code that produced tilt and parallax animations

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684af38d0d1c83259e194ef711a693b9