### PR TITLE
Add command toggle panel

### DIFF
--- a/commands-config.json
+++ b/commands-config.json
@@ -1,0 +1,10 @@
+{
+  "8ball": true,
+  "ban": true,
+  "help": true,
+  "kick": true,
+  "ping": true,
+  "poll": true,
+  "siema": true,
+  "userinfo": true
+}

--- a/web/admin.html
+++ b/web/admin.html
@@ -82,6 +82,7 @@
     </div>
     <nav>
       <a href="servers.html" class="link">Servers</a>
+      <a href="commands.html" class="link">Commands</a>
       <a href="/logout" class="link">Logout</a>
     </nav>
   </div>

--- a/web/commands.html
+++ b/web/commands.html
@@ -3,40 +3,36 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Select Discord server">
-  <title>Select Server</title>
+  <meta name="description" content="Manage commands">
+  <title>Commands</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Nova+Flat&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header class="topbar">
     <h2>MODSN.AI</h2>
     <nav>
-      <a href="index.html" class="link">Home</a>
+      <a href="servers.html" class="link">Servers</a>
     </nav>
   </header>
   <div class="sidebar">
     <div class="user-info">
       <img id="avatar" class="avatar" src="" alt="avatar">
       <div id="username"></div>
-      <p id="stats"></p>
-            <div id="invite"></div>
     </div>
     <nav>
-      <a href="commands.html" class="link">Commands</a>
+      <a href="servers.html" class="link">Servers</a>
       <a href="/logout" class="link">Logout</a>
     </nav>
   </div>
   <main class="main">
     <div class="card tilt">
-      <h1>SELECT SERVER</h1>
-      <ul id="guilds"></ul>
-      <p class="note">Select a server to manage its settings. If you don't see your server, make sure the bot is added to it.</p>
+      <h1>Commands</h1>
+      <ul id="commands"></ul>
     </div>
   </main>
   <footer class="footer">Panel MODSN.AI &copy; 2025</footer>
   <script src="script.js"></script>
-  <script src="servers.js"></script>
+  <script src="commands.js"></script>
 </body>
 </html>

--- a/web/commands.js
+++ b/web/commands.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadUserInfo();
+  const list = document.getElementById('commands');
+  const data = await fetchJSON('/command-status');
+  if (data) {
+    Object.entries(data).forEach(([name, enabled]) => {
+      const li = document.createElement('li');
+      const label = document.createElement('label');
+      label.textContent = name;
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = enabled;
+      input.addEventListener('change', async () => {
+        await fetch('/command-status', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command: name, enabled: input.checked })
+        });
+      });
+      label.prepend(input);
+      li.appendChild(label);
+      list.appendChild(li);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- allow reading command enablement state from `commands-config.json`
- expose web API to get/set command status
- add a new `/commands.html` page with switches
- link to new page from Admin and Servers screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684afb2c6b348325b1c2f3cf30de17a6