### PR TITLE
Enable per-server command toggles

### DIFF
--- a/commands-config.json
+++ b/commands-config.json
@@ -1,10 +1,13 @@
 {
-  "8ball": true,
-  "ban": true,
-  "help": true,
-  "kick": true,
-  "ping": true,
-  "poll": true,
-  "siema": true,
-  "userinfo": true
+  "default": {
+    "8ball": true,
+    "ban": true,
+    "help": true,
+    "kick": true,
+    "ping": true,
+    "poll": true,
+    "siema": true,
+    "userinfo": true
+  },
+  "guilds": {}
 }

--- a/web/commands.html
+++ b/web/commands.html
@@ -27,7 +27,7 @@
   </div>
   <main class="main">
     <div class="card tilt">
-      <h1>Commands</h1>
+      <h1 id="server-name">Commands</h1>
       <ul id="commands"></ul>
     </div>
   </main>

--- a/web/commands.js
+++ b/web/commands.js
@@ -1,23 +1,41 @@
 document.addEventListener('DOMContentLoaded', async () => {
   await loadUserInfo();
+  const params = new URLSearchParams(window.location.search);
+  const guildId = params.get('guildId');
+  if (!guildId) {
+    window.location.replace('servers.html');
+    return;
+  }
   const list = document.getElementById('commands');
-  const data = await fetchJSON('/command-status');
+  const header = document.getElementById('server-name');
+  try {
+    const guilds = await fetchJSON('/guilds');
+    const guild = guilds.find(g => g.id === guildId);
+    if (guild && header) header.textContent = `Commands - ${guild.name}`;
+  } catch (_) {}
+  const data = await fetchJSON(`/command-status/${guildId}`);
   if (data) {
     Object.entries(data).forEach(([name, enabled]) => {
       const li = document.createElement('li');
+      const span = document.createElement('span');
+      span.textContent = name;
       const label = document.createElement('label');
-      label.textContent = name;
+      label.className = 'switch';
       const input = document.createElement('input');
       input.type = 'checkbox';
       input.checked = enabled;
+      const slider = document.createElement('span');
+      slider.className = 'slider';
+      label.appendChild(input);
+      label.appendChild(slider);
       input.addEventListener('change', async () => {
-        await fetch('/command-status', {
+        await fetch(`/command-status/${guildId}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ command: name, enabled: input.checked })
         });
       });
-      label.prepend(input);
+      li.appendChild(span);
       li.appendChild(label);
       list.appendChild(li);
     });

--- a/web/styles.css
+++ b/web/styles.css
@@ -526,3 +526,66 @@ body.no-sidebar {
   text-align: center;
   margin-top: 5%;
 }
+
+#commands {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#commands li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+#commands li:last-child {
+  border-bottom: none;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 42px;
+  height: 22px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+  border-radius: 22px;
+}
+
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+  background-color: var(--primary);
+}
+
+.switch input:checked + .slider:before {
+  transform: translateX(20px);
+}


### PR DESCRIPTION
## Summary
- store command settings per guild in `commands-config.json`
- support per-guild command status in bot and web server
- add switch UI and guild selection on commands page
- style command list and switches

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684afc5154608325ab32677e4f621305