### PR TITLE
Fix commands page flow

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -21,6 +21,14 @@
       const form = document.getElementById('msgForm');
       const params = new URLSearchParams(window.location.search);
       const guildId = params.get('guildId');
+      const commandsLink = document.getElementById('commandsLink');
+      if (commandsLink) {
+        if (guildId) {
+          commandsLink.href = `commands.html?guildId=${guildId}`;
+        } else {
+          commandsLink.style.display = 'none';
+        }
+      }
 
       const loadChannels = async (id) => {
         channelSelect.innerHTML = '';
@@ -82,7 +90,7 @@
     </div>
     <nav>
       <a href="servers.html" class="link">Servers</a>
-      <a href="commands.html" class="link">Commands</a>
+      <a href="commands.html" id="commandsLink" class="link">Commands</a>
       <a href="/logout" class="link">Logout</a>
     </nav>
   </div>

--- a/web/servers.html
+++ b/web/servers.html
@@ -24,7 +24,6 @@
             <div id="invite"></div>
     </div>
     <nav>
-      <a href="commands.html" class="link">Commands</a>
       <a href="/logout" class="link">Logout</a>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- hide commands link on the server list page
- link to commands from admin zone with the chosen server id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684afd7aa8708325824b9453c9a1ac19