### PR TITLE
Add rich embed builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ node index.js
 Aplikacja wystartuje na porcie `3000`. Otwórz `http://localhost:3000` w przeglądarce i zaloguj się przez Discord.
 Jeżeli bot nie jest jeszcze na Twoim serwerze, skorzystaj z adresu `http://localhost:3000/invite` aby go dodać.
 
+## Embed messages
+
+W panelu administracyjnym znajdziesz sekcję **Rich Embed**, która pozwala zbudować zaawansowaną wiadomość z tytułem, opisem, kolorem oraz emoji. Gotowy embed możesz wysłać na wybrany kanał serwera.
+
 ## Testy
 
 W projekcie nie ma zdefiniowanych testów, ale polecenie `npm test` jest wymagane przed wysłaniem zmian.

--- a/web/admin.html
+++ b/web/admin.html
@@ -19,6 +19,11 @@
       const guildGroup = document.getElementById('guildGroup');
       const channelSelect = document.getElementById('channel');
       const form = document.getElementById('msgForm');
+      const embedForm = document.getElementById('embedForm');
+      const emojiSelect = document.getElementById('emoji');
+      const embedTitle = document.getElementById('embedTitle');
+      const embedDescription = document.getElementById('embedDescription');
+      const embedColor = document.getElementById('embedColor');
       const params = new URLSearchParams(window.location.search);
       const guildId = params.get('guildId');
       const commandsLink = document.getElementById('commandsLink');
@@ -72,6 +77,27 @@
         alert(await res.text());
         form.reset();
       });
+
+      if (embedForm) {
+        embedForm.addEventListener('submit', async (e) => {
+          e.preventDefault();
+          const body = {
+            channelId: channelSelect.value,
+            embed: {
+              title: embedTitle.value,
+              description: `${emojiSelect.value} ${embedDescription.value}`.trim(),
+              color: parseInt(embedColor.value.replace('#', ''), 16)
+            }
+          };
+          const res = await fetch('/embed', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+          });
+          alert(await res.text());
+          embedForm.reset();
+        });
+      }
     });
   </script>
 </head>
@@ -111,6 +137,33 @@
           <input type="text" id="message" required>
         </div>
         <button class="btn" style="margin-top:1rem;">Send</button>
+      </form>
+    </div>
+    <div class="card tilt" style="margin-top:2rem;">
+      <h2>Rich Embed</h2>
+      <form id="embedForm">
+        <div class="form-group">
+          <label>Title</label>
+          <input type="text" id="embedTitle" maxlength="256" required>
+        </div>
+        <div class="form-group">
+          <label>Description</label>
+          <textarea id="embedDescription" required></textarea>
+        </div>
+        <div class="form-group">
+          <label>Color</label>
+          <input type="color" id="embedColor" value="#5865F2">
+        </div>
+        <div class="form-group">
+          <label>Emoji Prefix</label>
+          <select id="emoji">
+            <option value="">None</option>
+            <option value="😀">😀 Smile</option>
+            <option value="🚀">🚀 Rocket</option>
+            <option value="🔥">🔥 Fire</option>
+          </select>
+        </div>
+        <button class="btn" style="margin-top:1rem;">Send Embed</button>
       </form>
     </div>
   </main>

--- a/web/server.js
+++ b/web/server.js
@@ -221,6 +221,22 @@ module.exports = function startWebServer(client) {
     }
   });
 
+  app.post('/embed', requireAuth, async (req, res) => {
+    const { channelId, embed } = req.body;
+    const channel = client.channels.cache.get(channelId);
+    if (!channel) return res.status(400).send('Channel not found');
+    if (!embed || typeof embed !== 'object') {
+      return res.status(400).send('Invalid embed');
+    }
+    try {
+      await channel.send({ embeds: [embed] });
+      res.send('Embed sent');
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Failed to send embed');
+    }
+  });
+
   app.listen(PORT, () =>
     console.log(`\uD83D\uDD0C Web management listening on port ${PORT}`)
   );


### PR DESCRIPTION
## Summary
- extend admin panel with a `Rich Embed` section to craft colored embed messages
- allow submitting embed messages with emoji prefix, title, description and color
- expose `/embed` API endpoint for sending embeds
- document the new feature in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684afebc6eb88325b6ef0b256c952075