### PR TITLE
Add advanced emoji picker and mention selectors

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -36,6 +36,10 @@
       const embedImage = document.getElementById('embedImage');
       const embedThumbnail = document.getElementById('embedThumbnail');
       const embedTimestamp = document.getElementById('embedTimestamp');
+      const mentionUserSelect = document.getElementById("mentionUser");
+      const mentionChannelSelect = document.getElementById("mentionChannel");
+      const messageInput = document.getElementById("message");
+      const customEmojiPicker = document.getElementById("customEmojiPicker");
       const embedFields = document.getElementById('embedFields');
       const descPreview = document.getElementById('descPreview');
       const params = new URLSearchParams(window.location.search);
@@ -65,6 +69,44 @@
               opt2.textContent = c.name;
               embedChannelSelect.appendChild(opt2);
             }
+          });
+        await loadMembers(id);
+        await loadEmojis(id);
+      };
+      const loadMembers = async (id) => {
+        if (!mentionUserSelect) return;
+        mentionUserSelect.innerHTML = "<option value="">--Select user--</option>";
+        const members = await fetchJSON(`/members/${id}`);
+        if (members)
+          members.forEach(m => {
+            const opt = document.createElement("option");
+            opt.value = m.id;
+            opt.textContent = m.name;
+            mentionUserSelect.appendChild(opt);
+          });
+      };
+
+      const loadEmojis = async (id) => {
+        if (!customEmojiPicker) return;
+        customEmojiPicker.innerHTML = "";
+        const emojis = await fetchJSON(`/emojis/${id}`);
+        if (emojis)
+          emojis.forEach(e => {
+            const img = document.createElement("img");
+            img.src = e.url;
+            img.alt = e.name;
+            img.title = `:${e.name}:`;
+            img.addEventListener("click", async () => {
+              const markup = e.animated ? `<a:${e.name}:${e.id}>` : `<:${e.name}:${e.id}>`;
+              emojiInput.value = markup;
+              try {
+                await navigator.clipboard.writeText(markup);
+              } catch (_) {}
+              emojiPicker.style.display = "none";
+              customEmojiPicker.style.display = "none";
+              updatePreview();
+            });
+            customEmojiPicker.appendChild(img);
           });
       };
 
@@ -105,6 +147,7 @@
 
       emojiInput.addEventListener('click', () => {
         emojiPicker.style.display = 'block';
+        if (customEmojiPicker) customEmojiPicker.style.display = 'flex';
       });
 
       emojiPicker.addEventListener('emoji-click', e => {
@@ -114,8 +157,13 @@
       });
 
       document.addEventListener('click', e => {
-        if (!emojiPicker.contains(e.target) && e.target !== emojiInput) {
+        if (
+          !emojiPicker.contains(e.target) &&
+          !customEmojiPicker.contains(e.target) &&
+          e.target !== emojiInput
+        ) {
           emojiPicker.style.display = 'none';
+          if (customEmojiPicker) customEmojiPicker.style.display = 'none';
         }
       });
 
@@ -202,6 +250,22 @@
       ].forEach(el => el && el.addEventListener('input', updatePreview));
 
       updatePreview();
+
+      if (mentionUserSelect)
+        mentionUserSelect.addEventListener('change', () => {
+          if (mentionUserSelect.value) {
+            messageInput.value += ` <@${mentionUserSelect.value}>`;
+            mentionUserSelect.selectedIndex = 0;
+          }
+        });
+
+      if (mentionChannelSelect)
+        mentionChannelSelect.addEventListener('change', () => {
+          if (mentionChannelSelect.value) {
+            messageInput.value += ` <#${mentionChannelSelect.value}>`;
+            mentionChannelSelect.selectedIndex = 0;
+          }
+        });
 
       form.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -297,6 +361,18 @@
           <label>Message</label>
           <input type="text" id="message" required>
         </div>
+        <div class="form-group">
+          <label>Mention User</label>
+          <select id="mentionUser">
+            <option value="">--Select user--</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Mention Channel</label>
+          <select id="mentionChannel">
+            <option value="">--Select channel--</option>
+          </select>
+        </div>
         <button class="btn" style="margin-top:1rem;">Send</button>
       </form>
     </div>
@@ -372,6 +448,7 @@
           <div class="emoji-picker-wrapper">
             <input type="text" id="emojiInput" readonly placeholder="Click to pick">
             <emoji-picker id="emojiPicker"></emoji-picker>
+            <div id="customEmojiPicker" class="custom-emoji-picker"></div>
           </div>
         </div>
         <div id="embedPreview" class="embed-preview"></div>

--- a/web/embed.css
+++ b/web/embed.css
@@ -33,6 +33,24 @@
   display: none;
   z-index: 10;
 }
+#customEmojiPicker {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  display: none;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  background-color: var(--card-bg-hover);
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+  z-index: 10;
+}
+#customEmojiPicker img {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
 .embed-preview {
   margin-top: 1rem;
   border-left: 3px solid var(--primary);

--- a/web/server.js
+++ b/web/server.js
@@ -226,6 +226,37 @@ module.exports = function startWebServer(client) {
     }
   });
 
+  app.get('/members/:guildId', requireAuth, verifyGuildAccess, async (req, res) => {
+    const guild = client.guilds.cache.get(req.params.guildId);
+    if (!guild) return res.status(404).send('Guild not found');
+    try {
+      await guild.members.fetch({ limit: 1000 });
+      const members = guild.members.cache.map(m => ({ id: m.user.id, name: m.user.username }));
+      res.json(members);
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Failed to fetch members');
+    }
+  });
+
+  app.get('/emojis/:guildId', requireAuth, verifyGuildAccess, async (req, res) => {
+    const guild = client.guilds.cache.get(req.params.guildId);
+    if (!guild) return res.status(404).send('Guild not found');
+    try {
+      await guild.emojis.fetch();
+      const emojis = guild.emojis.cache.map(e => ({
+        id: e.id,
+        name: e.name,
+        url: e.url,
+        animated: e.animated
+      }));
+      res.json(emojis);
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Failed to fetch emojis');
+    }
+  });
+
   app.post('/message', requireAuth, async (req, res) => {
     const { channelId, message } = req.body;
     const channel = client.channels.cache.get(channelId);

--- a/web/styles.css
+++ b/web/styles.css
@@ -337,6 +337,16 @@ body.no-sidebar {
   font-size: 1rem;
   transition: all var(--transition-fast);
 }
+.form-group select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='%23ccc' stroke-width='2' viewBox='0 0 24 24'%3e%3cpath d='M6 9l6 6 6-6'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1rem;
+  padding-right: 2.5rem;
+}
 
 .form-group input:focus,
 .form-group select:focus,


### PR DESCRIPTION
## Summary
- enable Discord custom emoji fetching in the admin panel
- add user/channel mention selectors
- show custom server emojis alongside emoji picker
- style select elements with custom arrow
- expose `/members/:guildId` and `/emojis/:guildId` routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b0a35cb6883258be72397c1ba53e2