### PR TITLE
Implement roles listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Jeżeli bot nie jest jeszcze na Twoim serwerze, skorzystaj z adresu `http://loca
 
 W panelu administracyjnym znajdziesz sekcję **Rich Embed**, która pozwala zbudować zaawansowaną wiadomość z tytułem, opisem, kolorem oraz emoji. Teraz dostępny jest picker emoji, przyciski do formatowania tekstu z podglądem oraz podgląd gotowego embed przed wysłaniem. Gotowy embed możesz wysłać na wybrany kanał serwera.
 
+## Roles overview
+
+Now the panel includes a **Roles** page where you can view server roles. Access it from the admin page once a guild is selected.
+
 ## Testy
 
 W projekcie nie ma zdefiniowanych testów, ale polecenie `npm test` jest wymagane przed wysłaniem zmian.

--- a/web/admin.html
+++ b/web/admin.html
@@ -42,11 +42,19 @@
       const params = new URLSearchParams(window.location.search);
       const guildId = params.get('guildId');
       const commandsLink = document.getElementById('commandsLink');
+      const rolesLink = document.getElementById('rolesLink');
       if (commandsLink) {
         if (guildId) {
           commandsLink.href = `commands.html?guildId=${guildId}`;
         } else {
           commandsLink.style.display = 'none';
+        }
+      }
+      if (rolesLink) {
+        if (guildId) {
+          rolesLink.href = `roles.html?guildId=${guildId}`;
+        } else {
+          rolesLink.style.display = 'none';
         }
       }
 
@@ -304,6 +312,7 @@
     <nav>
       <a href="servers.html" class="link">Servers</a>
       <a href="commands.html" id="commandsLink" class="link">Commands</a>
+      <a href="roles.html" id="rolesLink" class="link">Roles</a>
       <a href="/logout" class="link">Logout</a>
     </nav>
   </div>

--- a/web/roles.html
+++ b/web/roles.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="View roles">
+  <title>Roles</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Roboto+Slab:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <h2>MODSN.AI</h2>
+    <nav>
+      <a href="servers.html" class="link">Servers</a>
+    </nav>
+  </header>
+  <div class="sidebar">
+    <div class="user-info">
+      <img id="avatar" class="avatar" src="" alt="avatar">
+      <div id="username"></div>
+    </div>
+    <nav>
+      <a href="servers.html" class="link">Servers</a>
+      <a href="/logout" class="link">Logout</a>
+    </nav>
+  </div>
+  <main class="main">
+    <div class="card tilt">
+      <h1 id="server-name">Roles</h1>
+      <ul id="roles"></ul>
+    </div>
+  </main>
+  <footer class="footer">Panel MODSN.AI &copy; 2025</footer>
+  <script src="script.js"></script>
+  <script src="roles.js"></script>
+</body>
+</html>

--- a/web/roles.js
+++ b/web/roles.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadUserInfo();
+  const params = new URLSearchParams(window.location.search);
+  const guildId = params.get('guildId');
+  if (!guildId) {
+    window.location.replace('servers.html');
+    return;
+  }
+  const list = document.getElementById('roles');
+  const header = document.getElementById('server-name');
+  try {
+    const guilds = await fetchJSON('/guilds');
+    const guild = guilds.find(g => g.id === guildId);
+    if (guild && header) header.textContent = `Roles - ${guild.name}`;
+  } catch (_) {}
+  const roles = await fetchJSON(`/roles/${guildId}`);
+  if (roles) {
+    roles.forEach(role => {
+      const li = document.createElement('li');
+      li.textContent = role.name;
+      list.appendChild(li);
+    });
+  }
+});

--- a/web/server.js
+++ b/web/server.js
@@ -293,6 +293,34 @@ module.exports = function startWebServer(client) {
     }
   });
 
+  app.get('/roles/:guildId', requireAuth, verifyGuildAccess, async (req, res) => {
+    const guild = client.guilds.cache.get(req.params.guildId);
+    if (!guild) return res.status(404).send('Guild not found');
+    try {
+      const roles = (await guild.roles.fetch()).map(r => ({ id: r.id, name: r.name }));
+      res.json(roles);
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Failed to fetch roles');
+    }
+  });
+
+  app.get('/members/:guildId', requireAuth, verifyGuildAccess, async (req, res) => {
+    const guild = client.guilds.cache.get(req.params.guildId);
+    if (!guild) return res.status(404).send('Guild not found');
+    try {
+      const members = (await guild.members.fetch({ limit: 100 })).map(m => ({
+        id: m.id,
+        username: m.user.username,
+        avatar: m.user.displayAvatarURL({ size: 64 })
+      }));
+      res.json(members);
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Failed to fetch members');
+    }
+  });
+
   app.listen(PORT, () =>
     console.log(`\uD83D\uDD0C Web management listening on port ${PORT}`)
   );


### PR DESCRIPTION
## Summary
- list guild roles and members in API
- add new Roles page to view roles
- link to the roles page from Admin panel
- document roles page in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b198ab62883259378440a4ecb4a39