### PR TITLE
Add economy bank commands and role creation

### DIFF
--- a/commands/createrole.js
+++ b/commands/createrole.js
@@ -1,0 +1,30 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('createrole')
+    .setDescription('Create a new role')
+    .addStringOption(o =>
+      o.setName('name').setDescription('Role name').setRequired(true))
+    .addStringOption(o =>
+      o.setName('color').setDescription('Hex color, optional')),
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageRoles)) {
+      return interaction.reply({ content: 'Missing permission.', ephemeral: true });
+    }
+    const name = interaction.options.getString('name');
+    let color = interaction.options.getString('color');
+    if (color) {
+      if (!/^#?[0-9A-Fa-f]{6}$/.test(color)) {
+        return interaction.reply({ content: 'Invalid color.', ephemeral: true });
+      }
+      if (!color.startsWith('#')) color = `#${color}`;
+    }
+    try {
+      const role = await interaction.guild.roles.create({ name, color });
+      await interaction.reply({ content: `Created role ${role.name}.`, ephemeral: true });
+    } catch (_) {
+      await interaction.reply({ content: 'Failed to create role.', ephemeral: true });
+    }
+  }
+};

--- a/commands/deposit.js
+++ b/commands/deposit.js
@@ -1,0 +1,18 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('deposit')
+    .setDescription('Deposit coins into your bank')
+    .addIntegerOption(o =>
+      o.setName('amount').setDescription('Amount').setRequired(true).setMinValue(1)),
+  async execute(interaction) {
+    const amount = interaction.options.getInteger('amount');
+    try {
+      interaction.client.economy.deposit(interaction.user.id, amount);
+      await interaction.reply(`Deposited ${amount} coins to your bank.`);
+    } catch (e) {
+      await interaction.reply({ content: 'Deposit failed: ' + e.message, ephemeral: true });
+    }
+  }
+};

--- a/commands/withdraw.js
+++ b/commands/withdraw.js
@@ -1,0 +1,18 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('withdraw')
+    .setDescription('Withdraw coins from your bank')
+    .addIntegerOption(o =>
+      o.setName('amount').setDescription('Amount').setRequired(true).setMinValue(1)),
+  async execute(interaction) {
+    const amount = interaction.options.getInteger('amount');
+    try {
+      interaction.client.economy.withdraw(interaction.user.id, amount);
+      await interaction.reply(`Withdrew ${amount} coins from your bank.`);
+    } catch (e) {
+      await interaction.reply({ content: 'Withdraw failed: ' + e.message, ephemeral: true });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- allow depositing to and withdrawing from bank via new `deposit` and `withdraw` commands
- enable creating Discord roles with `createrole`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b2054ed3c832590ca918800591578