### PR TITLE
Add gamble command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ W panelu administracyjnym znajdziesz sekcję **Rich Embed**, która pozwala zbud
 
 Now the panel includes a **Roles** page where you can view server roles. Access it from the admin page once a guild is selected.
 
+## Economy commands
+
+Bot includes an in-chat economy. Use `/daily` and `/work` to earn coins, `/deposit` and `/withdraw` to manage your bank balance and `/gamble` to risk your coins for a chance to double them.
+
 ## Testy
 
 W projekcie nie ma zdefiniowanych testów, ale polecenie `npm test` jest wymagane przed wysłaniem zmian.

--- a/commands/gamble.js
+++ b/commands/gamble.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('gamble')
+    .setDescription('Gamble coins with a 50% chance to double them')
+    .addIntegerOption(o =>
+      o.setName('amount').setDescription('Amount to gamble').setRequired(true).setMinValue(1)),
+  async execute(interaction) {
+    const amount = interaction.options.getInteger('amount');
+    try {
+      const reward = interaction.client.economy.gamble(interaction.user.id, amount);
+      if (reward > 0) {
+        await interaction.reply(`You won and gained ${reward} coins!`);
+      } else {
+        await interaction.reply(`You lost ${amount} coins.`);
+      }
+    } catch (e) {
+      await interaction.reply({ content: 'Gamble failed: ' + e.message, ephemeral: true });
+    }
+  }
+};

--- a/economy.js
+++ b/economy.js
@@ -1164,6 +1164,17 @@ EconomySystem.prototype.withdrawAll = function (id) {
   this.withdraw(id, user.bank);
 };
 
+EconomySystem.prototype.gamble = function (id, amount) {
+  this.subtractBalance(id, amount, 'gamble-bet');
+  const win = Math.random() < 0.5;
+  if (win) {
+    const reward = amount * 2;
+    this.addBalance(id, reward, 'gamble-win');
+    return reward;
+  }
+  return 0;
+};
+
 EconomySystem.prototype.inventoryValue = function (id) {
   const user = this.getUser(id);
   return user.inventory

--- a/web/economy.js
+++ b/web/economy.js
@@ -49,6 +49,29 @@ document.addEventListener('DOMContentLoaded', async () => {
       alert(text);
     }
   });
+
+  document.getElementById('gambleBtn')?.addEventListener('click', async () => {
+    const amt = parseInt(amountInput.value, 10);
+    if (amt > 0) {
+      const res = await fetch('/economy/gamble', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: amt })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.reward > 0) {
+          alert('You won!');
+        } else {
+          alert('You lost.');
+        }
+        await refreshEconomy();
+      } else {
+        const text = await res.text();
+        alert(text);
+      }
+    }
+  });
 });
 
 async function refreshEconomy() {

--- a/web/server.js
+++ b/web/server.js
@@ -428,6 +428,19 @@ module.exports = function startWebServer(client) {
     }
   });
 
+  app.post('/economy/gamble', requireAuth, async (req, res) => {
+    try {
+      const id = await getUserId(req);
+      const amt = parseInt(req.body.amount, 10);
+      const reward = client.economy.gamble(id, amt);
+      const user = client.economy.getUser(id);
+      res.json({ balance: user.balance, bank: user.bank, reward });
+    } catch (err) {
+      console.error(err);
+      res.status(400).send(err.message);
+    }
+  });
+
   app.listen(PORT, () =>
     console.log(`\uD83D\uDD0C Web management listening on port ${PORT}`)
   );

--- a/web/user.html
+++ b/web/user.html
@@ -39,6 +39,7 @@
     <div style="margin-top: 0.5rem;">
       <button id="dailyBtn" class="btn btn-sm" type="button">Claim Daily</button>
       <button id="workBtn" class="btn btn-sm" type="button">Work</button>
+      <button id="gambleBtn" class="btn btn-sm" type="button">Gamble</button>
     </div>
   </div>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- introduce `/gamble` command using new economy.gamble()
- extend EconomySystem with gamble function
- expose gamble API route and web UI button
- document economy commands

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b2203e6f48325a2a14d057e0c95fd