### PR TITLE
Redirect non-admins to user panel

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -44,6 +44,16 @@
       const commandsLink = document.getElementById('commandsLink');
       const rolesLink = document.getElementById('rolesLink');
       const roleManagerLink = document.getElementById('roleManagerLink');
+
+      if (guildId) {
+        const guilds = await fetchJSON('/guilds');
+        const guild = guilds && guilds.find(g => g.id === guildId);
+        const isAdmin = guild && (guild.owner || (BigInt(guild.permissions) & 0x8n) === 0x8n);
+        if (!isAdmin) {
+          window.location.replace('user.html');
+          return;
+        }
+      }
       if (commandsLink) {
         if (guildId) {
           commandsLink.href = `commands.html?guildId=${guildId}`;

--- a/web/servers.js
+++ b/web/servers.js
@@ -13,7 +13,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       const li = document.createElement('li');
       const link = document.createElement('a');
       link.textContent = g.name;
-      link.href = `admin.html?guildId=${g.id}`;
+      const isAdmin = g.owner || (BigInt(g.permissions) & 0x8n) === 0x8n;
+      link.href = isAdmin ? `admin.html?guildId=${g.id}` : 'user.html';
       li.appendChild(link);
       list.appendChild(li);
     });


### PR DESCRIPTION
## Summary
- detect admin rights when listing guilds
- redirect to the user panel if viewer lacks administrator permission for a guild

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b239b4f648325920c7ec06bd2908f