### PR TITLE
Fix economy init and move css

### DIFF
--- a/economy.js
+++ b/economy.js
@@ -12,6 +12,8 @@ class EconomySystem {
     try {
       const raw = fs.readFileSync(this.file, 'utf8');
       this.data = JSON.parse(raw);
+      if (typeof this.data.users !== 'object') this.data.users = {};
+      if (!Array.isArray(this.data.shop)) this.data.shop = [];
     } catch (_) {
       this.save();
     }
@@ -36,6 +38,7 @@ class EconomySystem {
   }
 
   addBalance(id, amt, reason = 'earn') {
+    if (amt <= 0) throw new Error('Amount must be positive');
     const user = this.getUser(id);
     user.balance += amt;
     user.transactions.push({ type: reason, amount: amt, ts: Date.now() });
@@ -44,6 +47,7 @@ class EconomySystem {
 
   subtractBalance(id, amt, reason = 'spend') {
     const user = this.getUser(id);
+    if (amt <= 0) throw new Error('Amount must be positive');
     if (user.balance < amt) throw new Error('Insufficient funds');
     user.balance -= amt;
     user.transactions.push({ type: reason, amount: -amt, ts: Date.now() });
@@ -52,6 +56,7 @@ class EconomySystem {
 
   deposit(id, amt) {
     const user = this.getUser(id);
+    if (amt <= 0) throw new Error('Amount must be positive');
     if (user.balance < amt) throw new Error('Insufficient funds');
     user.balance -= amt;
     user.bank += amt;
@@ -61,6 +66,7 @@ class EconomySystem {
 
   withdraw(id, amt) {
     const user = this.getUser(id);
+    if (amt <= 0) throw new Error('Amount must be positive');
     if (user.bank < amt) throw new Error('Insufficient bank funds');
     user.bank -= amt;
     user.balance += amt;

--- a/web/admin.html
+++ b/web/admin.html
@@ -7,7 +7,6 @@
   <title>Admin Zone</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Roboto+Slab:wght@600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
-  <link rel="stylesheet" href="embed.css">
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
       const user = await loadUserInfo();

--- a/web/user.html
+++ b/web/user.html
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Roboto+Slab:wght@600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="embed.css">
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
       await loadUserInfo();


### PR DESCRIPTION
## Summary
- guard against missing economy data
- validate positive amounts in economy methods
- move embed.css inclusion from admin panel to user page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b256aba7c832595a211470ca0b213