### PR TITLE
Improve info embeds

### DIFF
--- a/commands/serverinfo.js
+++ b/commands/serverinfo.js
@@ -6,10 +6,18 @@ module.exports = {
     .setDescription('Displays information about the server'),
   async execute(interaction) {
     const { guild } = interaction;
+    const owner = await guild.fetchOwner();
     const embed = interaction.client.createEmbed(interaction.guildId, {
       title: guild.name,
+      thumbnail: { url: guild.iconURL() },
       fields: [
-        { name: 'Members', value: String(guild.memberCount), inline: true }
+        { name: 'ID', value: guild.id, inline: true },
+        { name: 'Owner', value: owner.user.tag, inline: true },
+        { name: 'Created', value: guild.createdAt.toDateString(), inline: true },
+        { name: 'Members', value: String(guild.memberCount), inline: true },
+        { name: 'Channels', value: String(guild.channels.cache.size), inline: true },
+        { name: 'Roles', value: String(guild.roles.cache.size), inline: true },
+        { name: 'Boosts', value: String(guild.premiumSubscriptionCount || 0), inline: true }
       ]
     });
     await interaction.reply({ embeds: [embed] });

--- a/commands/userinfo.js
+++ b/commands/userinfo.js
@@ -12,12 +12,18 @@ module.exports = {
   async execute(interaction) {
     const user = interaction.options.getUser('uzytkownik') || interaction.user;
     const member = interaction.guild.members.cache.get(user.id);
+    const roles = member.roles.cache
+      .filter(r => r.name !== '@everyone')
+      .map(r => r.name)
+      .join(', ') || 'Brak';
     const embed = interaction.client.createEmbed(interaction.guildId, {
       title: user.tag,
       thumbnail: { url: user.displayAvatarURL() },
       fields: [
+        { name: 'ID', value: user.id, inline: true },
         { name: 'Dołączył na serwer', value: member.joinedAt.toDateString(), inline: true },
-        { name: 'Utworzone konto', value: user.createdAt.toDateString(), inline: true }
+        { name: 'Utworzone konto', value: user.createdAt.toDateString(), inline: true },
+        { name: 'Role', value: roles, inline: false }
       ]
     });
     await interaction.reply({ embeds: [embed] });

--- a/index.js
+++ b/index.js
@@ -49,7 +49,15 @@ client.setEmbedColor = function (guildId, color) {
   guildSettings.set(guildId, { color });
 };
 client.createEmbed = function (guildId, data = {}) {
-  return { color: this.getEmbedColor(guildId), ...data };
+  const defaults = {
+    color: this.getEmbedColor(guildId),
+    timestamp: new Date(),
+    footer: {
+      text: this.user ? this.user.username : '',
+      icon_url: this.user ? this.user.displayAvatarURL() : null
+    }
+  };
+  return { ...defaults, ...data };
 };
 
 const commandsPath = path.join(__dirname, 'commands');


### PR DESCRIPTION
## Summary
- add default timestamp and footer for embeds
- expand `/serverinfo` output with more guild details
- show additional user info in `/userinfo`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b31cf0454832584d0b3ac4ecce117