### PR TITLE
Add advanced commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ Now the panel includes a **Roles** page where you can view server roles. Access 
 
 Bot includes an in-chat economy. Use `/daily` and `/work` to earn coins, `/deposit` and `/withdraw` to manage your bank balance and `/gamble` to risk your coins for a chance to double them.
 
+## Advanced commands
+
+Bot oferuje także szereg bardziej rozbudowanych komend:
+
+- `/weather <miasto>` - aktualna pogoda.
+- `/translate <tekst> <lang>` - tłumaczenie na wybrany język.
+- `/remind <minuty> <tekst>` - przypomnienie po czasie.
+- `/quote` - losowy cytat.
+- `/stock <symbol>` - cena akcji.
+- `/meme` - losowy mem z internetu.
+- `/crypto <id>` - kurs kryptowaluty.
+- `/define <słowo>` - definicja słowa po angielsku.
+- `/dog` - zdjęcie psa.
+- `/time` - aktualny czas UTC.
+
 ## Testy
 
 W projekcie nie ma zdefiniowanych testów, ale polecenie `npm test` jest wymagane przed wysłaniem zmian.

--- a/commands-config.json
+++ b/commands-config.json
@@ -23,6 +23,16 @@
     "addrole": true,
     "removerole": true,
     "membercount": true
+    ,"weather": true
+    ,"translate": true
+    ,"remind": true
+    ,"quote": true
+    ,"stock": true
+    ,"meme": true
+    ,"crypto": true
+    ,"define": true
+    ,"dog": true
+    ,"time": true
   },
   "guilds": {}
 }

--- a/commands/crypto.js
+++ b/commands/crypto.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('crypto')
+    .setDescription('Sprawdza cenę kryptowaluty')
+    .addStringOption(o =>
+      o.setName('id').setDescription('Nazwa (id) kryptowaluty, np. bitcoin').setRequired(true)),
+  async execute(interaction) {
+    const id = interaction.options.getString('id');
+    try {
+      const res = await fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${encodeURIComponent(id)}&vs_currencies=usd`);
+      const data = await res.json();
+      if (!data[id] || !data[id].usd) throw new Error('Brak danych');
+      const price = data[id].usd;
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: `Cena ${id}: $${price}` });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się pobrać ceny.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};

--- a/commands/define.js
+++ b/commands/define.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('define')
+    .setDescription('Definicja angielskiego słowa')
+    .addStringOption(o =>
+      o.setName('word').setDescription('Słowo').setRequired(true)),
+  async execute(interaction) {
+    const word = interaction.options.getString('word');
+    try {
+      const res = await fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${encodeURIComponent(word)}`);
+      const data = await res.json();
+      const meaning = data[0].meanings[0].definitions[0].definition;
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: `${word}: ${meaning}` });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się znaleźć definicji.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};

--- a/commands/dog.js
+++ b/commands/dog.js
@@ -1,0 +1,18 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('dog')
+    .setDescription('Losowe zdjęcie psa'),
+  async execute(interaction) {
+    try {
+      const res = await fetch('https://random.dog/woof.json');
+      const data = await res.json();
+      const embed = interaction.client.createEmbed(interaction.guildId, { image: { url: data.url } });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się pobrać psa.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};

--- a/commands/meme.js
+++ b/commands/meme.js
@@ -1,0 +1,21 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('meme')
+    .setDescription('Wysyła losowego mema'),
+  async execute(interaction) {
+    try {
+      const res = await fetch('https://meme-api.com/gimme');
+      const data = await res.json();
+      const embed = interaction.client.createEmbed(interaction.guildId, {
+        title: data.title,
+        image: { url: data.url }
+      });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się pobrać mema.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};

--- a/commands/quote.js
+++ b/commands/quote.js
@@ -1,0 +1,18 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('quote')
+    .setDescription('Losowy cytat'),
+  async execute(interaction) {
+    try {
+      const res = await fetch('https://api.quotable.io/random');
+      const data = await res.json();
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: `${data.content} — ${data.author}` });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się pobrać cytatu.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};

--- a/commands/remind.js
+++ b/commands/remind.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('remind')
+    .setDescription('Wysyła przypomnienie po określonym czasie')
+    .addIntegerOption(o =>
+      o.setName('minutes').setDescription('Za ile minut').setRequired(true).setMinValue(1))
+    .addStringOption(o =>
+      o.setName('text').setDescription('Treść przypomnienia').setRequired(true)),
+  async execute(interaction) {
+    const minutes = interaction.options.getInteger('minutes');
+    const text = interaction.options.getString('text');
+    const embed = interaction.client.createEmbed(interaction.guildId, {
+      description: `Przypomnę za ${minutes} minut: ${text}`
+    });
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    setTimeout(() => {
+      interaction.followUp({ content: `<@${interaction.user.id}> ${text}` });
+    }, minutes * 60 * 1000);
+  }
+};

--- a/commands/stock.js
+++ b/commands/stock.js
@@ -1,0 +1,26 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('stock')
+    .setDescription('Sprawdza cenę akcji')
+    .addStringOption(o =>
+      o.setName('symbol').setDescription('Symbol akcji').setRequired(true)),
+  async execute(interaction) {
+    const symbol = interaction.options.getString('symbol');
+    try {
+      const url = `https://stooq.pl/q/l/?s=${encodeURIComponent(symbol)}.us&f=sd2ohlcv&h&e=csv`;
+      const res = await fetch(url);
+      const text = await res.text();
+      const lines = text.trim().split('\n');
+      if (lines.length < 2) throw new Error('Brak danych');
+      const parts = lines[1].split(',');
+      const price = parts[5];
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: `Cena ${symbol.toUpperCase()}: ${price}` });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się pobrać ceny akcji.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};

--- a/commands/time.js
+++ b/commands/time.js
@@ -1,0 +1,18 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('time')
+    .setDescription('Aktualny czas UTC'),
+  async execute(interaction) {
+    try {
+      const res = await fetch('https://worldtimeapi.org/api/timezone/Etc/UTC');
+      const data = await res.json();
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: data.datetime });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się pobrać czasu.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};

--- a/commands/translate.js
+++ b/commands/translate.js
@@ -1,0 +1,28 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('translate')
+    .setDescription('Tłumaczy tekst na wybrany język')
+    .addStringOption(o =>
+      o.setName('text').setDescription('Tekst do przetłumaczenia').setRequired(true))
+    .addStringOption(o =>
+      o.setName('lang').setDescription('Kod języka docelowego').setRequired(true)),
+  async execute(interaction) {
+    const text = interaction.options.getString('text');
+    const lang = interaction.options.getString('lang');
+    try {
+      const res = await fetch('https://libretranslate.de/translate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ q: text, source: 'auto', target: lang })
+      });
+      const data = await res.json();
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: data.translatedText });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Tłumaczenie nie powiodło się.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};

--- a/commands/weather.js
+++ b/commands/weather.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('weather')
+    .setDescription('Wyświetla aktualną pogodę dla wybranego miasta')
+    .addStringOption(o =>
+      o.setName('city').setDescription('Nazwa miasta').setRequired(true)),
+  async execute(interaction) {
+    const city = interaction.options.getString('city');
+    try {
+      const response = await fetch(`https://wttr.in/${encodeURIComponent(city)}?format=j1`);
+      const data = await response.json();
+      const current = data.current_condition[0];
+      const desc = `${current.temp_C}°C, ${current.weatherDesc[0].value}`;
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: desc });
+      await interaction.reply({ embeds: [embed] });
+    } catch (e) {
+      const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się pobrać pogody.' });
+      await interaction.reply({ embeds: [embedErr], ephemeral: true });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- create advanced bot commands (weather, translate, remind, quote, stock, meme, crypto, define, dog, time)
- enable these commands by default
- document new commands in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b33e281cc8325abae859ba5899ff2