### PR TITLE
Add advanced options to selected commands

### DIFF
--- a/commands/8ball.js
+++ b/commands/8ball.js
@@ -4,12 +4,17 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('8ball')
     .setDescription('Odpowiada na pytania tak/nie')
+    .addBooleanOption(o =>
+      o.setName('prywatnie')
+        .setDescription('Wyświetl odpowiedź prywatnie')
+    )
     .addStringOption(option =>
       option.setName('pytanie')
         .setDescription('Treść pytania')
         .setRequired(true)
     ),
   async execute(interaction) {
+    const ephemeral = interaction.options.getBoolean('prywatnie') ?? false;
     const responses = [
       'Tak',
       'Nie',
@@ -21,6 +26,6 @@ module.exports = {
     ];
     const response = responses[Math.floor(Math.random() * responses.length)];
     const embed = interaction.client.createEmbed(interaction.guildId, { description: response });
-    await interaction.reply({ embeds: [embed] });
+    await interaction.reply({ embeds: [embed], ephemeral });
   }
 };

--- a/commands/ban.js
+++ b/commands/ban.js
@@ -4,10 +4,25 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('ban')
     .setDescription('Banuje wskazanego użytkownika')
+    .addBooleanOption(o =>
+      o.setName('prywatnie')
+        .setDescription('Wyświetl odpowiedź prywatnie')
+    )
     .addUserOption(option =>
       option.setName('uzytkownik')
         .setDescription('Użytkownik do zbanowania')
         .setRequired(true)
+    )
+    .addIntegerOption(o =>
+      o.setName('days')
+        .setDescription('Ile dni wiadomości usunąć (0-7)')
+        .setMinValue(0)
+        .setMaxValue(7)
+    )
+    .addStringOption(o =>
+      o.setName('reason')
+        .setDescription('Powód bana')
+        .setRequired(false)
     ),
   async execute(interaction) {
     if (!interaction.member.permissions.has(PermissionsBitField.Flags.BanMembers)) {
@@ -15,14 +30,17 @@ module.exports = {
       return interaction.reply({ embeds: [embed], ephemeral: true });
     }
     const member = interaction.options.getMember('uzytkownik');
+    const days = interaction.options.getInteger('days') ?? 0;
+    const reason = interaction.options.getString('reason') ?? 'Brak powodu';
+    const ephemeral = interaction.options.getBoolean('prywatnie') ?? false;
     if (!member) {
       const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie mogę znaleźć użytkownika.' });
       return interaction.reply({ embeds: [embedErr], ephemeral: true });
     }
     try {
-      await member.ban();
-      const embed = interaction.client.createEmbed(interaction.guildId, { description: `Użytkownik ${member.user.tag} został zbanowany.` });
-      await interaction.reply({ embeds: [embed] });
+      await member.ban({ deleteMessageDays: days, reason });
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: `Użytkownik ${member.user.tag} został zbanowany. Powód: ${reason}` });
+      await interaction.reply({ embeds: [embed], ephemeral });
     } catch (err) {
       console.error(err);
       const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się zbanować użytkownika.' });

--- a/commands/help.js
+++ b/commands/help.js
@@ -3,8 +3,13 @@ const { SlashCommandBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('help')
-    .setDescription('Wyświetla listę komend'),
+    .setDescription('Wyświetla listę komend')
+    .addBooleanOption(o =>
+      o.setName('prywatnie')
+        .setDescription('Wyświetl odpowiedź prywatnie')
+    ),
   async execute(interaction) {
+    const ephemeral = interaction.options.getBoolean('prywatnie') ?? false;
     const commands = interaction.client.commands
       .map(cmd => {
         const count = interaction.client.getCommandUsage(cmd.data.name);
@@ -12,6 +17,6 @@ module.exports = {
       })
       .join('\n');
     const embed = interaction.client.createEmbed(interaction.guildId, { description: `Dostępne komendy:\n${commands}` });
-    await interaction.reply({ embeds: [embed] });
+    await interaction.reply({ embeds: [embed], ephemeral });
   }
 };

--- a/commands/kick.js
+++ b/commands/kick.js
@@ -4,10 +4,19 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('kick')
     .setDescription('Wyrzuca wskazanego użytkownika z serwera')
+    .addBooleanOption(o =>
+      o.setName('prywatnie')
+        .setDescription('Wyświetl odpowiedź prywatnie')
+    )
     .addUserOption(option =>
       option.setName('uzytkownik')
         .setDescription('Użytkownik do wyrzucenia')
         .setRequired(true)
+    )
+    .addStringOption(o =>
+      o.setName('reason')
+        .setDescription('Powód wyrzucenia')
+        .setRequired(false)
     ),
   async execute(interaction) {
     if (!interaction.member.permissions.has(PermissionsBitField.Flags.KickMembers)) {
@@ -15,14 +24,16 @@ module.exports = {
       return interaction.reply({ embeds: [embed], ephemeral: true });
     }
     const member = interaction.options.getMember('uzytkownik');
+    const reason = interaction.options.getString('reason') ?? 'Brak powodu';
+    const ephemeral = interaction.options.getBoolean('prywatnie') ?? false;
     if (!member) {
       const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie mogę znaleźć użytkownika.' });
       return interaction.reply({ embeds: [embedErr], ephemeral: true });
     }
     try {
-      await member.kick();
-      const embed = interaction.client.createEmbed(interaction.guildId, { description: `Użytkownik ${member.user.tag} został wyrzucony.` });
-      await interaction.reply({ embeds: [embed] });
+      await member.kick(reason);
+      const embed = interaction.client.createEmbed(interaction.guildId, { description: `Użytkownik ${member.user.tag} został wyrzucony. Powód: ${reason}` });
+      await interaction.reply({ embeds: [embed], ephemeral });
     } catch (err) {
       console.error(err);
       const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się wyrzucić użytkownika.' });

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -3,9 +3,14 @@ const { SlashCommandBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('ping')
-    .setDescription('Sprawdź czy bot działa'),
+    .setDescription('Sprawdź czy bot działa')
+    .addBooleanOption(o =>
+      o.setName('prywatnie')
+        .setDescription('Wyświetl odpowiedź prywatnie')
+    ),
   async execute(interaction) {
-    const sent = await interaction.reply({ content: 'Pinging...', fetchReply: true });
+    const ephemeral = interaction.options.getBoolean('prywatnie') ?? false;
+    const sent = await interaction.reply({ content: 'Pinging...', fetchReply: true, ephemeral });
     const latency = sent.createdTimestamp - interaction.createdTimestamp;
     const embed = interaction.client.createEmbed(interaction.guildId, { description: `Pong! **${latency}ms**` });
     await interaction.editReply({ content: null, embeds: [embed] });

--- a/commands/poll.js
+++ b/commands/poll.js
@@ -8,12 +8,28 @@ module.exports = {
       option.setName('pytanie')
         .setDescription('Treść ankiety')
         .setRequired(true)
+    )
+    .addIntegerOption(o =>
+      o.setName('czas')
+        .setDescription('Czas trwania w minutach')
+        .setRequired(false)
+        .setMinValue(1)
     ),
   async execute(interaction) {
     const question = interaction.options.getString('pytanie');
+    const duration = interaction.options.getInteger('czas');
     const embed = interaction.client.createEmbed(interaction.guildId, { description: `📊 **${question}**` });
     const pollMessage = await interaction.reply({ embeds: [embed], fetchReply: true });
     await pollMessage.react('👍');
     await pollMessage.react('👎');
+    if (duration) {
+      setTimeout(async () => {
+        const fetched = await interaction.channel.messages.fetch(pollMessage.id);
+        const up = fetched.reactions.cache.get('👍')?.count - 1 || 0;
+        const down = fetched.reactions.cache.get('👎')?.count - 1 || 0;
+        const result = interaction.client.createEmbed(interaction.guildId, { description: `Wynik ankiety: 👍 ${up} / 👎 ${down}` });
+        interaction.followUp({ embeds: [result] });
+      }, duration * 60 * 1000);
+    }
   }
 };

--- a/commands/remind.js
+++ b/commands/remind.js
@@ -4,6 +4,10 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('remind')
     .setDescription('Wysyła przypomnienie po określonym czasie')
+    .addBooleanOption(o =>
+      o.setName('prywatnie')
+        .setDescription('Wyświetl przypomnienie prywatnie')
+    )
     .addIntegerOption(o =>
       o.setName('minutes').setDescription('Za ile minut').setRequired(true).setMinValue(1))
     .addStringOption(o =>
@@ -11,12 +15,13 @@ module.exports = {
   async execute(interaction) {
     const minutes = interaction.options.getInteger('minutes');
     const text = interaction.options.getString('text');
+    const ephemeral = interaction.options.getBoolean('prywatnie') ?? false;
     const embed = interaction.client.createEmbed(interaction.guildId, {
       description: `Przypomnę za ${minutes} minut: ${text}`
     });
-    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await interaction.reply({ embeds: [embed], ephemeral });
     setTimeout(() => {
-      interaction.followUp({ content: `<@${interaction.user.id}> ${text}` });
+      interaction.followUp({ content: `<@${interaction.user.id}> ${text}`, ephemeral });
     }, minutes * 60 * 1000);
   }
 };

--- a/commands/translate.js
+++ b/commands/translate.js
@@ -4,22 +4,30 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('translate')
     .setDescription('Tłumaczy tekst na wybrany język')
+    .addBooleanOption(o =>
+      o.setName('prywatnie')
+        .setDescription('Wyświetl odpowiedź prywatnie')
+    )
     .addStringOption(o =>
       o.setName('text').setDescription('Tekst do przetłumaczenia').setRequired(true))
     .addStringOption(o =>
-      o.setName('lang').setDescription('Kod języka docelowego').setRequired(true)),
+      o.setName('lang').setDescription('Kod języka docelowego').setRequired(true))
+    .addStringOption(o =>
+      o.setName('source').setDescription('Kod języka źródłowego').setRequired(false)),
   async execute(interaction) {
     const text = interaction.options.getString('text');
     const lang = interaction.options.getString('lang');
+    const source = interaction.options.getString('source') || 'auto';
+    const ephemeral = interaction.options.getBoolean('prywatnie') ?? false;
     try {
       const res = await fetch('https://libretranslate.de/translate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ q: text, source: 'auto', target: lang })
+        body: JSON.stringify({ q: text, source, target: lang })
       });
       const data = await res.json();
       const embed = interaction.client.createEmbed(interaction.guildId, { description: data.translatedText });
-      await interaction.reply({ embeds: [embed] });
+      await interaction.reply({ embeds: [embed], ephemeral });
     } catch (e) {
       const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Tłumaczenie nie powiodło się.' });
       await interaction.reply({ embeds: [embedErr], ephemeral: true });

--- a/commands/weather.js
+++ b/commands/weather.js
@@ -4,17 +4,30 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('weather')
     .setDescription('Wyświetla aktualną pogodę dla wybranego miasta')
+    .addBooleanOption(o =>
+      o.setName('prywatnie')
+        .setDescription('Wyświetl odpowiedź prywatnie')
+    )
     .addStringOption(o =>
-      o.setName('city').setDescription('Nazwa miasta').setRequired(true)),
+      o.setName('city').setDescription('Nazwa miasta').setRequired(true))
+    .addStringOption(o =>
+      o.setName('units')
+        .setDescription('Jednostki: metric lub imperial')
+        .setRequired(false)
+    ),
   async execute(interaction) {
     const city = interaction.options.getString('city');
+    const units = interaction.options.getString('units') || 'metric';
+    const ephemeral = interaction.options.getBoolean('prywatnie') ?? false;
     try {
-      const response = await fetch(`https://wttr.in/${encodeURIComponent(city)}?format=j1`);
+      const format = units === 'imperial' ? 'u' : 'm';
+      const response = await fetch(`https://wttr.in/${encodeURIComponent(city)}?format=j1&${format}`);
       const data = await response.json();
       const current = data.current_condition[0];
-      const desc = `${current.temp_C}°C, ${current.weatherDesc[0].value}`;
+      const temp = units === 'imperial' ? `${current.temp_F}°F` : `${current.temp_C}°C`;
+      const desc = `${temp}, ${current.weatherDesc[0].value}`;
       const embed = interaction.client.createEmbed(interaction.guildId, { description: desc });
-      await interaction.reply({ embeds: [embed] });
+      await interaction.reply({ embeds: [embed], ephemeral });
     } catch (e) {
       const embedErr = interaction.client.createEmbed(interaction.guildId, { description: 'Nie udało się pobrać pogody.' });
       await interaction.reply({ embeds: [embedErr], ephemeral: true });


### PR DESCRIPTION
## Summary
- extend ban and kick commands with reason, delete days and ephemeral
- add private reply option to help, ping, 8ball and remind commands
- enhance weather and translate commands with advanced options
- support timed polls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b38e363348325ab8532dd6cf38c9d