### PR TITLE
Add advanced web settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,12 +116,28 @@ client.on('interactionCreate', async interaction => {
 
 client.on('guildMemberAdd', member => {
   const settings = guildSettings.get(member.guild.id);
+  if (settings.autoRole) {
+    const role = member.guild.roles.cache.get(settings.autoRole);
+    if (role) member.roles.add(role).catch(console.error);
+  }
+  if (settings.logChannel) {
+    const logCh = member.guild.channels.cache.get(settings.logChannel);
+    if (logCh) logCh.send({ content: `${member.user.tag} joined the server.` }).catch(console.error);
+  }
   if (settings.welcomeChannel && settings.welcomeMessage) {
     const channel = member.guild.channels.cache.get(settings.welcomeChannel);
     if (channel) {
       const msg = settings.welcomeMessage.replace('{user}', `<@${member.id}>`);
       channel.send({ content: msg }).catch(console.error);
     }
+  }
+});
+
+client.on('guildMemberRemove', member => {
+  const settings = guildSettings.get(member.guild.id);
+  if (settings.logChannel) {
+    const logCh = member.guild.channels.cache.get(settings.logChannel);
+    if (logCh) logCh.send({ content: `${member.user.tag} left the server.` }).catch(console.error);
   }
 });
 

--- a/web/admin.html
+++ b/web/admin.html
@@ -43,6 +43,9 @@
       const welcomeChannelSelect = document.getElementById('welcomeChannel');
       const welcomeMessageInput = document.getElementById('welcomeMessage');
       const saveWelcome = document.getElementById('saveWelcome');
+      const logChannelSelect = document.getElementById('logChannel');
+      const autoRoleSelect = document.getElementById('autoRole');
+      const saveAdvanced = document.getElementById('saveAdvanced');
       const params = new URLSearchParams(window.location.search);
       const guildId = params.get('guildId');
       const commandsLink = document.getElementById('commandsLink');
@@ -91,7 +94,11 @@
       if (guildId && defaultColor) {
         try {
           const settings = await fetchJSON(`/settings/${guildId}`);
-          if (settings && settings.color) defaultColor.value = settings.color;
+          if (settings) {
+            if (settings.color) defaultColor.value = settings.color;
+            if (logChannelSelect && settings.logChannel) logChannelSelect.value = settings.logChannel;
+            if (autoRoleSelect && settings.autoRole) autoRoleSelect.value = settings.autoRole;
+          }
         } catch (_) {}
         try {
           const w = await fetchJSON(`/welcome-settings/${guildId}`);
@@ -133,6 +140,24 @@
             }
           });
         }
+        if (saveAdvanced) {
+          saveAdvanced.addEventListener('click', async () => {
+            try {
+              const res = await fetch(`/settings/${guildId}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  logChannel: logChannelSelect.value,
+                  autoRole: autoRoleSelect.value
+                })
+              });
+              const text = await res.text();
+              if (res.ok) notify('success', text); else notify('error', text);
+            } catch (err) {
+              notify('error', err.message);
+            }
+          });
+        }
       } else if (defaultColor && saveSettings) {
         defaultColor.disabled = true;
         saveSettings.disabled = true;
@@ -145,6 +170,7 @@
         channelSelect.innerHTML = '';
         if (embedChannelSelect) embedChannelSelect.innerHTML = '';
         if (welcomeChannelSelect) welcomeChannelSelect.innerHTML = '';
+        if (logChannelSelect) logChannelSelect.innerHTML = '<option value="">None</option>';
         const channels = await fetchJSON(`/channels/${id}`);
         if (channels)
           channels.forEach(c => {
@@ -163,6 +189,12 @@
               opt3.value = c.id;
               opt3.textContent = c.name;
               welcomeChannelSelect.appendChild(opt3);
+            }
+            if (logChannelSelect) {
+              const opt4 = document.createElement('option');
+              opt4.value = c.id;
+              opt4.textContent = c.name;
+              logChannelSelect.appendChild(opt4);
             }
           });
       };
@@ -184,10 +216,24 @@
           });
       };
 
+      const loadRoles = async (id) => {
+        if (!autoRoleSelect) return;
+        autoRoleSelect.innerHTML = '<option value="">None</option>';
+        const roles = await fetchJSON(`/roles/${id}`);
+        if (roles)
+          roles.forEach(r => {
+            const opt = document.createElement('option');
+            opt.value = r.id;
+            opt.textContent = r.name;
+            autoRoleSelect.appendChild(opt);
+          });
+      };
+
       if (guildId) {
         guildGroup.style.display = 'none';
         await loadChannels(guildId);
         await loadEmojis(guildId);
+        await loadRoles(guildId);
       } else {
         const guilds = await fetchJSON('/guilds');
         if (guilds)
@@ -200,6 +246,7 @@
         guildSelect.addEventListener('change', () => {
           loadChannels(guildSelect.value);
           loadEmojis(guildSelect.value);
+          loadRoles(guildSelect.value);
         });
         guildSelect.dispatchEvent(new Event('change'));
       }
@@ -536,6 +583,18 @@
         <small>Use {user} to mention the new member</small>
       </div>
       <button id="saveWelcome" class="btn" style="margin-top:1rem;">Save Welcome</button>
+    </div>
+    <div class="card tilt" style="margin-top:2rem;">
+      <h2>Advanced Settings</h2>
+      <div class="form-group">
+        <label>Log Channel</label>
+        <select id="logChannel"></select>
+      </div>
+      <div class="form-group">
+        <label>Auto Role</label>
+        <select id="autoRole"></select>
+      </div>
+      <button id="saveAdvanced" class="btn" style="margin-top:1rem;">Save Advanced</button>
     </div>
   </main>
   <div id="notifications" class="notifications"></div>

--- a/web/server.js
+++ b/web/server.js
@@ -237,11 +237,27 @@ module.exports = function startWebServer(client) {
 
   app.post('/settings/:guildId', requireAuth, verifyGuildAccess, (req, res) => {
     const guildId = req.params.guildId;
-    const { color } = req.body;
-    if (typeof color !== 'string' || !/^#?[0-9a-fA-F]{6}$/.test(color)) {
-      return res.status(400).send('Invalid color');
+    const { color, logChannel, autoRole } = req.body;
+    const update = {};
+    if (color !== undefined) {
+      if (typeof color !== 'string' || !/^#?[0-9a-fA-F]{6}$/.test(color)) {
+        return res.status(400).send('Invalid color');
+      }
+      update.color = color.startsWith('#') ? color : '#' + color;
     }
-    client.setEmbedColor(guildId, color.startsWith('#') ? color : '#' + color);
+    if (logChannel !== undefined) {
+      if (typeof logChannel !== 'string') {
+        return res.status(400).send('Invalid logChannel');
+      }
+      update.logChannel = logChannel;
+    }
+    if (autoRole !== undefined) {
+      if (typeof autoRole !== 'string') {
+        return res.status(400).send('Invalid autoRole');
+      }
+      update.autoRole = autoRole;
+    }
+    if (Object.keys(update).length) client.guildSettings.set(guildId, update);
     res.send('OK');
   });
 


### PR DESCRIPTION
## Summary
- support log channel and autorole settings in web server
- assign autorole and log joins/leaves in Discord bot
- extend admin panel with new advanced settings UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b403cd8708325ba20c565db7402f4