### PR TITLE
Add leave message settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,13 @@ client.on('guildMemberRemove', member => {
     const logCh = member.guild.channels.cache.get(settings.logChannel);
     if (logCh) logCh.send({ content: `${member.user.tag} left the server.` }).catch(console.error);
   }
+  if (settings.leaveChannel && settings.leaveMessage) {
+    const channel = member.guild.channels.cache.get(settings.leaveChannel);
+    if (channel) {
+      const msg = settings.leaveMessage.replace('{user}', `<@${member.id}>`);
+      channel.send({ content: msg }).catch(console.error);
+    }
+  }
 });
 
 client.login(process.env.DISCORD_TOKEN);

--- a/web/admin.html
+++ b/web/admin.html
@@ -43,6 +43,9 @@
       const welcomeChannelSelect = document.getElementById('welcomeChannel');
       const welcomeMessageInput = document.getElementById('welcomeMessage');
       const saveWelcome = document.getElementById('saveWelcome');
+      const leaveChannelSelect = document.getElementById('leaveChannel');
+      const leaveMessageInput = document.getElementById('leaveMessage');
+      const saveLeave = document.getElementById('saveLeave');
       const logChannelSelect = document.getElementById('logChannel');
       const autoRoleSelect = document.getElementById('autoRole');
       const saveAdvanced = document.getElementById('saveAdvanced');
@@ -107,6 +110,13 @@
             if (w.message && welcomeMessageInput) welcomeMessageInput.value = w.message;
           }
         } catch (_) {}
+        try {
+          const l = await fetchJSON(`/leave-settings/${guildId}`);
+          if (l) {
+            if (l.channel && leaveChannelSelect) leaveChannelSelect.value = l.channel;
+            if (l.message && leaveMessageInput) leaveMessageInput.value = l.message;
+          }
+        } catch (_) {}
         if (saveSettings) {
           saveSettings.addEventListener('click', async () => {
             try {
@@ -140,6 +150,24 @@
             }
           });
         }
+        if (saveLeave) {
+          saveLeave.addEventListener('click', async () => {
+            try {
+              const res = await fetch(`/leave-settings/${guildId}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  channel: leaveChannelSelect.value,
+                  message: leaveMessageInput.value
+                })
+              });
+              const text = await res.text();
+              if (res.ok) notify('success', text); else notify('error', text);
+            } catch (err) {
+              notify('error', err.message);
+            }
+          });
+        }
         if (saveAdvanced) {
           saveAdvanced.addEventListener('click', async () => {
             try {
@@ -164,12 +192,16 @@
         if (welcomeChannelSelect) welcomeChannelSelect.disabled = true;
         if (welcomeMessageInput) welcomeMessageInput.disabled = true;
         if (saveWelcome) saveWelcome.disabled = true;
+        if (leaveChannelSelect) leaveChannelSelect.disabled = true;
+        if (leaveMessageInput) leaveMessageInput.disabled = true;
+        if (saveLeave) saveLeave.disabled = true;
       }
 
       const loadChannels = async (id) => {
         channelSelect.innerHTML = '';
         if (embedChannelSelect) embedChannelSelect.innerHTML = '';
         if (welcomeChannelSelect) welcomeChannelSelect.innerHTML = '';
+        if (leaveChannelSelect) leaveChannelSelect.innerHTML = '';
         if (logChannelSelect) logChannelSelect.innerHTML = '<option value="">None</option>';
         const channels = await fetchJSON(`/channels/${id}`);
         if (channels)
@@ -189,6 +221,12 @@
               opt3.value = c.id;
               opt3.textContent = c.name;
               welcomeChannelSelect.appendChild(opt3);
+            }
+            if (leaveChannelSelect) {
+              const optL = document.createElement('option');
+              optL.value = c.id;
+              optL.textContent = c.name;
+              leaveChannelSelect.appendChild(optL);
             }
             if (logChannelSelect) {
               const opt4 = document.createElement('option');
@@ -584,6 +622,19 @@
         <small>Use {user} to mention the new member</small>
       </div>
       <button id="saveWelcome" class="btn" style="margin-top:1rem;">Save Welcome</button>
+    </div>
+    <div class="card tilt" style="margin-top:2rem;">
+      <h2>Leave Settings</h2>
+      <div class="form-group">
+        <label>Leave Channel</label>
+        <select id="leaveChannel"></select>
+      </div>
+      <div class="form-group">
+        <label>Leave Message</label>
+        <input type="text" id="leaveMessage">
+        <small>Use {user} to mention the member</small>
+      </div>
+      <button id="saveLeave" class="btn" style="margin-top:1rem;">Save Leave</button>
     </div>
     <div class="card tilt" style="margin-top:2rem;">
       <h2>Advanced Settings</h2>

--- a/web/server.js
+++ b/web/server.js
@@ -280,6 +280,25 @@ module.exports = function startWebServer(client) {
     res.send('OK');
   });
 
+  app.get('/leave-settings/:guildId', requireAuth, verifyGuildAccess, (req, res) => {
+    const guildId = req.params.guildId;
+    const set = client.guildSettings.get(guildId);
+    res.json({
+      channel: set.leaveChannel || '',
+      message: set.leaveMessage || ''
+    });
+  });
+
+  app.post('/leave-settings/:guildId', requireAuth, verifyGuildAccess, (req, res) => {
+    const guildId = req.params.guildId;
+    const { channel, message } = req.body;
+    if (typeof channel !== 'string' || typeof message !== 'string') {
+      return res.status(400).send('Invalid payload');
+    }
+    client.guildSettings.set(guildId, { leaveChannel: channel, leaveMessage: message });
+    res.send('OK');
+  });
+
   app.get('/guilds', requireAuth, async (req, res) => {
     try {
       const guilds = await fetchUserGuilds(req);


### PR DESCRIPTION
## Summary
- support configuring leave messages via web panel
- implement /leave-settings API
- update admin panel with Leave Settings card and logic
- send configured leave message when member leaves

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b4d7fab648325a98bd1950e560acb