### PR TITLE
Add server info page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ W panelu administracyjnym znajdziesz sekcję **Rich Embed**, która pozwala zbud
 
 Now the panel includes a **Roles** page where you can view server roles. Access it from the admin page once a guild is selected.
 
+## Server info
+
+From the admin page you can open **Server Info** to view details about the selected guild. The page shows member count, owner ID, creation date and server icon.
+
 ## Economy commands
 
 Bot includes an in-chat economy. Use `/daily` and `/work` to earn coins, `/deposit` and `/withdraw` to manage your bank balance and `/gamble` to risk your coins for a chance to double them.

--- a/web/admin.html
+++ b/web/admin.html
@@ -53,6 +53,7 @@
       const guildId = params.get('guildId');
       const commandsLink = document.getElementById('commandsLink');
       const rolesLink = document.getElementById('rolesLink');
+      const serverInfoLink = document.getElementById('serverInfoLink');
       const roleManagerLink = document.getElementById('roleManagerLink');
       const economyLink = document.getElementById('economyLink');
 
@@ -77,6 +78,13 @@
           rolesLink.href = `roles.html?guildId=${guildId}`;
         } else {
           rolesLink.style.display = 'none';
+        }
+      }
+      if (serverInfoLink) {
+        if (guildId) {
+          serverInfoLink.href = `server-info.html?guildId=${guildId}`;
+        } else {
+          serverInfoLink.style.display = 'none';
         }
       }
       if (roleManagerLink) {
@@ -498,6 +506,7 @@
       <a href="servers.html" class="link">Servers</a>
       <a href="commands.html" id="commandsLink" class="link">Commands</a>
       <a href="roles.html" id="rolesLink" class="link">Roles</a>
+      <a href="server-info.html" id="serverInfoLink" class="link">Server Info</a>
       <a href="role-manager.html" id="roleManagerLink" class="link">Role Manager</a>
       <a href="economy-admin.html" id="economyLink" class="link">Economy</a>
       <a href="economy-config.html" id="economyConfigLink" class="link">Economy Settings</a>

--- a/web/server-info.html
+++ b/web/server-info.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Server info">
+  <title>Server Info</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Roboto+Slab:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <h2>MODSN.AI</h2>
+    <nav>
+      <a href="servers.html" class="link">Servers</a>
+    </nav>
+  </header>
+  <div class="sidebar">
+    <div class="user-info">
+      <img id="avatar" class="avatar" src="" alt="avatar">
+      <div id="username"></div>
+    </div>
+    <nav>
+      <a href="servers.html" class="link">Servers</a>
+      <a href="/logout" class="link">Logout</a>
+    </nav>
+  </div>
+  <main class="main">
+    <div class="card tilt">
+      <h1 id="server-name">Server Info</h1>
+      <div id="info"></div>
+    </div>
+  </main>
+  <footer class="footer">Panel MODSN.AI &copy; 2025</footer>
+  <script src="script.js"></script>
+  <script src="server-info.js"></script>
+</body>
+</html>

--- a/web/server-info.js
+++ b/web/server-info.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadUserInfo();
+  const params = new URLSearchParams(window.location.search);
+  const guildId = params.get('guildId');
+  if (!guildId) {
+    window.location.replace('servers.html');
+    return;
+  }
+  const infoDiv = document.getElementById('info');
+  const header = document.getElementById('server-name');
+  try {
+    const data = await fetchJSON(`/server-info/${guildId}`);
+    if (header) header.textContent = `Server Info - ${data.name}`;
+    if (infoDiv) {
+      const created = new Date(data.createdAt).toLocaleString();
+      infoDiv.innerHTML = `
+        <p><strong>ID:</strong> ${data.id}</p>
+        <p><strong>Owner ID:</strong> ${data.ownerId}</p>
+        <p><strong>Members:</strong> ${data.memberCount}</p>
+        <p><strong>Created:</strong> ${created}</p>
+        ${data.description ? `<p>${data.description}</p>` : ''}
+        ${data.icon ? `<img src="${data.icon}" alt="icon" style="width:128px;height:128px;">` : ''}
+      `;
+    }
+  } catch (err) {
+    notify('error', err.message);
+  }
+});

--- a/web/server.js
+++ b/web/server.js
@@ -340,6 +340,26 @@ module.exports = function startWebServer(client) {
     }
   });
 
+  app.get('/server-info/:guildId', requireAuth, verifyGuildAccess, async (req, res) => {
+    const guild = client.guilds.cache.get(req.params.guildId);
+    if (!guild) return res.status(404).send('Guild not found');
+    try {
+      await guild.fetch();
+      res.json({
+        id: guild.id,
+        name: guild.name,
+        memberCount: guild.memberCount,
+        ownerId: guild.ownerId,
+        createdAt: guild.createdAt,
+        icon: guild.iconURL({ size: 128 }) || null,
+        description: guild.description || ''
+      });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Failed to fetch server info');
+    }
+  });
+
   app.post('/message', requireAuth, async (req, res) => {
     const { channelId, message } = req.body;
     const channel = client.channels.cache.get(channelId);

--- a/web/servers.js
+++ b/web/servers.js
@@ -23,6 +23,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         const isAdmin = g.owner || (BigInt(g.permissions) & 0x8n) === 0x8n;
         link.href = isAdmin ? `admin.html?guildId=${g.id}` : 'user.html';
         li.appendChild(link);
+        if (isAdmin) {
+          const info = document.createElement('a');
+          info.className = 'btn btn-sm';
+          info.textContent = 'Info';
+          info.href = `server-info.html?guildId=${g.id}`;
+          li.appendChild(info);
+        }
         list.appendChild(li);
       });
   }


### PR DESCRIPTION
## Summary
- provide a new `/server-info/:guildId` route
- display server info from the admin sidebar
- link to the info page from the servers list
- document the new page in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b5044c6cc8325bebe9ffcce8955f7