### PR TITLE
Add members page with DM support

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -56,6 +56,7 @@
       const serverInfoLink = document.getElementById('serverInfoLink');
       const roleManagerLink = document.getElementById('roleManagerLink');
       const economyLink = document.getElementById('economyLink');
+      const membersLink = document.getElementById('membersLink');
 
       if (guildId) {
         const guilds = await fetchJSON('/guilds');
@@ -92,6 +93,13 @@
           roleManagerLink.href = `role-manager.html?guildId=${guildId}`;
         } else {
           roleManagerLink.style.display = 'none';
+        }
+      }
+      if (membersLink) {
+        if (guildId) {
+          membersLink.href = `members.html?guildId=${guildId}`;
+        } else {
+          membersLink.style.display = 'none';
         }
       }
       if (economyLink) {
@@ -507,6 +515,7 @@
       <a href="commands.html" id="commandsLink" class="link">Commands</a>
       <a href="roles.html" id="rolesLink" class="link">Roles</a>
       <a href="server-info.html" id="serverInfoLink" class="link">Server Info</a>
+      <a href="members.html" id="membersLink" class="link">Members</a>
       <a href="role-manager.html" id="roleManagerLink" class="link">Role Manager</a>
       <a href="economy-admin.html" id="economyLink" class="link">Economy</a>
       <a href="economy-config.html" id="economyConfigLink" class="link">Economy Settings</a>

--- a/web/members.html
+++ b/web/members.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="View members">
+  <title>Members</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Roboto+Slab:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <h2>MODSN.AI</h2>
+    <nav>
+      <a href="servers.html" class="link">Servers</a>
+    </nav>
+  </header>
+  <div class="sidebar">
+    <div class="user-info">
+      <img id="avatar" class="avatar" src="" alt="avatar">
+      <div id="username"></div>
+    </div>
+    <nav>
+      <a href="servers.html" class="link">Servers</a>
+      <a href="/logout" class="link">Logout</a>
+    </nav>
+  </div>
+  <main class="main">
+    <div class="card tilt">
+      <h1 id="server-name">Members</h1>
+      <ul id="members"></ul>
+    </div>
+  </main>
+  <div id="notifications" class="notifications"></div>
+  <footer class="footer">Panel MODSN.AI &copy; 2025</footer>
+  <script src="script.js"></script>
+  <script src="members.js"></script>
+</body>
+</html>

--- a/web/members.js
+++ b/web/members.js
@@ -1,0 +1,53 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadUserInfo();
+  const params = new URLSearchParams(window.location.search);
+  const guildId = params.get('guildId');
+  if (!guildId) {
+    window.location.replace('servers.html');
+    return;
+  }
+  const list = document.getElementById('members');
+  const header = document.getElementById('server-name');
+  try {
+    const guilds = await fetchJSON('/guilds');
+    const guild = guilds.find(g => g.id === guildId);
+    if (guild && header) header.textContent = `Members - ${guild.name}`;
+  } catch (_) {}
+  const members = await fetchJSON(`/members/${guildId}`);
+  if (members) {
+    members.forEach(m => {
+      const li = document.createElement('li');
+      li.style.display = 'flex';
+      li.style.alignItems = 'center';
+      li.style.gap = '0.5rem';
+      const img = document.createElement('img');
+      img.className = 'avatar';
+      img.style.width = '32px';
+      img.style.height = '32px';
+      img.src = m.avatar;
+      const span = document.createElement('span');
+      span.textContent = m.username;
+      const btn = document.createElement('button');
+      btn.className = 'btn btn-sm';
+      btn.textContent = 'DM';
+      btn.addEventListener('click', async () => {
+        const msg = prompt('Enter message to send via bot');
+        if (!msg) return;
+        try {
+          await fetchJSON(`/dm/${m.id}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: msg })
+          });
+          notify('success', 'DM sent');
+        } catch (err) {
+          notify('error', err.message);
+        }
+      });
+      li.appendChild(img);
+      li.appendChild(span);
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+  }
+});

--- a/web/server.js
+++ b/web/server.js
@@ -613,6 +613,22 @@ module.exports = function startWebServer(client) {
     }
   });
 
+  app.post('/dm/:userId', requireAuth, async (req, res) => {
+    const { userId } = req.params;
+    const { message } = req.body;
+    if (typeof message !== 'string' || !message.trim() || message.length > 2000) {
+      return res.status(400).send('Invalid message');
+    }
+    try {
+      const user = await client.users.fetch(userId);
+      await user.send(message);
+      res.send('OK');
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Failed to send DM');
+    }
+  });
+
   app.listen(PORT, () =>
     console.log(`\uD83D\uDD0C Web management listening on port ${PORT}`)
   );

--- a/web/styles.css
+++ b/web/styles.css
@@ -656,3 +656,27 @@ body.no-sidebar {
 .toast .icon {
   font-size: 1.2rem;
 }
+
+#members {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#members li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+#members li:last-child {
+  border-bottom: none;
+}
+
+#members .avatar {
+  width: 32px;
+  height: 32px;
+  border-width: 2px;
+}


### PR DESCRIPTION
## Summary
- implement `/dm/:userId` endpoint in web server
- add new Members page listing guild members and enabling DM from the web panel
- include navigation link in admin panel
- style member list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b551c559c8325a8ea7837040488d5